### PR TITLE
feat(audit_wsdl): rewrite discovery to parse official Yandex Direct docs

### DIFF
--- a/scripts/audit_wsdl.py
+++ b/scripts/audit_wsdl.py
@@ -2,33 +2,42 @@
 """
 WSDL Audit Script for tapi-yandex-direct.
 
-Compares library coverage against Yandex Direct API v5 WSDL definitions.
+Compares library coverage against official live Yandex Direct API docs and
+WSDL definitions.
 Prints a Markdown report to stdout. Optionally creates a GitHub issue.
 
 Usage:
     python scripts/audit_wsdl.py
     python scripts/audit_wsdl.py --output report.md
+    python scripts/audit_wsdl.py --versions v5,v501,v4
     python scripts/audit_wsdl.py --issue
 """
 
 import argparse
+import os
+import re
 import subprocess
 import sys
+import tempfile
+from collections import deque
 from datetime import date
+from html.parser import HTMLParser
+from typing import NamedTuple
+from urllib.parse import urljoin, urlparse
 from xml.etree import ElementTree as ET
 
 import requests
 
-WSDL_BASE_URL = "https://api.direct.yandex.com/v5/{service}?wsdl"
-GITHUB_API_URL = "https://api.github.com/repos/dragonsigh/yandex-direct-api-docs/contents/"
+DOCS_BASE_URL = "https://yandex.com/dev/direct/doc/en/"
+V4_DOCS_BASE_URL = "https://yandex.com/dev/direct/doc/dg-v4/en/"
 
 WSDL_NS = "http://schemas.xmlsoap.org/wsdl/"
-
-# Folders in the docs repo that are NOT API services
-DOCS_REPO_NON_SERVICE_DIRS = {
-    "concepts", "objects", "images", ".github", "examples",
-    "reports", "changes", "dictionaries",
-}
+SERVICE_LINK_RE = re.compile(r"/dev/direct/doc/en/([^/#?]+)/\1(?:[#?].*)?$")
+V4_METHOD_LINK_RE = re.compile(r"/dev/direct/doc/dg-v4/en/(?:reference|live)/([^/#?]+)")
+WSDL_URL_RE = re.compile(r"https://api\.direct\.yandex\.com/(v\d+)/([^/?#]+)\?wsdl")
+SOAP_URL_RE = re.compile(r"https://api\.direct\.yandex\.com/(?!json/)(v\d+)/([^/?#\s]+)")
+JSON_URL_RE = re.compile(r"https://api\.direct\.yandex\.com/json/(v\d+)/([^/?#\s]+)")
+METHOD_NAME_RE = re.compile(r"\b[A-Za-z][A-Za-z0-9]*(?:_[A-Za-z0-9]+)?\b")
 
 # Resource types for clear categorization
 # wsdl       — SOAP/WSDL service, auditable
@@ -80,106 +89,358 @@ KNOWN_NON_WSDL_METHODS: dict[str, set[str]] = {
     "dictionaries": {"getGeoRegions"},
 }
 
-# Fallback service list if GitHub API is unavailable
-FALLBACK_SERVICES = sorted(info["endpoint"] for info in WSDL_RESOURCES.values())
+
+class DiscoveredService(NamedTuple):
+    version: str
+    name: str
+    endpoint: str
+    docs_url: str
+    methods: set[str]
+    wsdl_url: str
+    soap_url: str | None
+    json_url: str | None
 
 
-def discover_services_from_github() -> list[str]:
-    """Get list of all v5 API services from dragonsigh/yandex-direct-api-docs repo structure."""
-    print(f"Fetching service list from GitHub: {GITHUB_API_URL} ...")
-    try:
-        resp = requests.get(
-            GITHUB_API_URL,
-            headers={"Accept": "application/vnd.github+json"},
-            timeout=15,
-        )
-        resp.raise_for_status()
-        entries = resp.json()
-    except requests.RequestException as e:
-        print(f"  Warning: could not fetch GitHub API: {e}")
-        print("  Using fallback service list.")
-        return FALLBACK_SERVICES
+class LegacyMethod(NamedTuple):
+    name: str
+    docs_url: str
 
-    services = sorted(
-        entry["name"]
-        for entry in entries
-        if entry["type"] == "dir" and entry["name"] not in DOCS_REPO_NON_SERVICE_DIRS
-    )
 
-    if not services:
-        print("  Warning: no service directories found. Using fallback list.")
-        return FALLBACK_SERVICES
+class _LinkParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.links: list[tuple[str, str]] = []
+        self._current_href: str | None = None
+        self._current_text: list[str] = []
 
-    print(f"  Found {len(services)} services: {', '.join(services)}")
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag != "a":
+            return
+        attrs_dict = dict(attrs)
+        href = attrs_dict.get("href")
+        if href:
+            self._current_href = href
+            self._current_text = []
+
+    def handle_data(self, data: str) -> None:
+        if self._current_href:
+            self._current_text.append(data)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "a" and self._current_href:
+            text = " ".join(" ".join(self._current_text).split())
+            self.links.append((self._current_href, text))
+            self._current_href = None
+            self._current_text = []
+
+
+class _TextParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.parts: list[str] = []
+
+    def handle_data(self, data: str) -> None:
+        text = " ".join(data.split())
+        if text:
+            self.parts.append(text)
+
+    @property
+    def text(self) -> str:
+        return " ".join(self.parts)
+
+
+def _html_text(html: str) -> str:
+    parser = _TextParser()
+    parser.feed(html)
+    return parser.text
+
+
+def _docs_root(base_url: str, lang: str = "en") -> str:
+    marker = f"/{lang}/"
+    if marker in base_url:
+        return base_url.split(marker, 1)[0] + "/"
+    return base_url if base_url.endswith("/") else base_url + "/"
+
+
+def _normalize_docs_url(href: str, base_url: str, lang: str = "en") -> str:
+    if re.match(rf"^{lang}/", href):
+        absolute = urljoin(_docs_root(base_url, lang), href)
+    else:
+        absolute = urljoin(base_url, href)
+
+    parsed = urlparse(absolute)
+    return parsed._replace(query="", fragment="").geturl()
+
+
+def _extract_service_name(text: str, docs_url: str) -> str:
+    match = re.search(r"(?:^|\s)([A-Z][A-Za-z0-9]+):", text)
+    if match:
+        return match.group(1).strip()
+
+    path_parts = [part for part in urlparse(docs_url).path.split("/") if part]
+    endpoint = path_parts[-1] if path_parts else "unknown"
+    return endpoint[:1].upper() + endpoint[1:]
+
+
+def _extract_methods(text: str) -> set[str]:
+    match = re.search(r"Methods[:.]?\s*(.*?)(?:WSDL|SOAP|JSON|Request|Restrictions|$)", text)
+    if not match:
+        return set()
+
+    methods = set()
+    for candidate in METHOD_NAME_RE.findall(match.group(1)):
+        if candidate.lower() in {"methods", "method", "and", "or"}:
+            continue
+        methods.add(candidate)
+    return methods
+
+
+def _extract_methods_from_links(links: list[tuple[str, str]], docs_url: str) -> set[str]:
+    path_parts = [part for part in urlparse(docs_url).path.split("/") if part]
+    if not path_parts:
+        return set()
+
+    endpoint = path_parts[-1]
+    methods: set[str] = set()
+    for href, text in links:
+        path = urlparse(_normalize_docs_url(href, docs_url)).path
+        parts = [part for part in path.split("/") if part]
+        if len(parts) < 2 or parts[-2] != endpoint:
+            continue
+
+        method = parts[-1]
+        if method == endpoint:
+            continue
+        if not METHOD_NAME_RE.fullmatch(method):
+            continue
+        methods.add(method)
+
+    return methods
+
+
+def parse_v5_service_links(html: str, base_url: str = DOCS_BASE_URL) -> list[str]:
+    """Extract official v5 service page links from Yandex docs navigation."""
+    parser = _LinkParser()
+    parser.feed(html)
+
+    links: list[str] = []
+    seen: set[str] = set()
+    for href, _text in parser.links:
+        absolute = _normalize_docs_url(href, base_url)
+        if not SERVICE_LINK_RE.search(urlparse(absolute).path):
+            continue
+        if absolute not in seen:
+            seen.add(absolute)
+            links.append(absolute)
+
+    return links
+
+
+def parse_v4_method_links(html: str, base_url: str = V4_DOCS_BASE_URL) -> list[LegacyMethod]:
+    """Extract legacy v4 method links from official Yandex Direct v4 docs."""
+    parser = _LinkParser()
+    parser.feed(html)
+
+    methods: list[LegacyMethod] = []
+    seen: set[str] = set()
+    for href, text in parser.links:
+        absolute = _normalize_docs_url(href, base_url)
+        match = V4_METHOD_LINK_RE.search(urlparse(absolute).path)
+        if not match:
+            continue
+        slug = match.group(1)
+        if slug in {"_AllMethods", "ErrorCodes"}:
+            continue
+        name = text.strip() or slug
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        methods.append(LegacyMethod(name=name, docs_url=absolute))
+
+    return methods
+
+
+def parse_v5_service_page(html: str, docs_url: str) -> list[DiscoveredService]:
+    """Extract versioned WSDL/SOAP/JSON service records from a service docs page."""
+    text = _html_text(html)
+    link_parser = _LinkParser()
+    link_parser.feed(html)
+    link_text = " ".join(href for href, _text in link_parser.links)
+    all_text = f"{text} {link_text}"
+    name = _extract_service_name(text, docs_url)
+    methods = _extract_methods_from_links(link_parser.links, docs_url) or _extract_methods(text)
+
+    soap_urls: dict[tuple[str, str], str] = {}
+    for version, endpoint in SOAP_URL_RE.findall(all_text):
+        soap_urls.setdefault((version, endpoint), f"https://api.direct.yandex.com/{version}/{endpoint}")
+
+    json_urls: dict[tuple[str, str], str] = {}
+    for version, endpoint in JSON_URL_RE.findall(all_text):
+        json_urls[(version, endpoint)] = f"https://api.direct.yandex.com/json/{version}/{endpoint}"
+
+    services: list[DiscoveredService] = []
+    seen: set[tuple[str, str]] = set()
+    for version, endpoint in WSDL_URL_RE.findall(all_text):
+        key = (version, endpoint)
+        if key in seen:
+            continue
+        seen.add(key)
+        services.append(DiscoveredService(
+            version=version,
+            name=name,
+            endpoint=endpoint,
+            docs_url=docs_url,
+            methods=set(methods),
+            wsdl_url=f"https://api.direct.yandex.com/{version}/{endpoint}?wsdl",
+            soap_url=soap_urls.get(key),
+            json_url=json_urls.get(key),
+        ))
+
     return services
 
 
-def fetch_wsdl_operations(service: str) -> tuple[set[str], bool]:
-    """Fetch WSDL for a service and extract operation names from portType."""
-    url = WSDL_BASE_URL.format(service=service)
+def _get_text(url: str, timeout: int) -> str:
+    resp = requests.get(url, timeout=timeout)
+    resp.raise_for_status()
+    return resp.text
+
+
+def discover_v5_services_from_docs(base_url: str, timeout: int) -> list[DiscoveredService]:
+    """Load official Yandex docs and extract all versioned service records."""
+    print(f"Fetching official Yandex Direct docs index: {base_url} ...", file=sys.stderr)
     try:
-        resp = requests.get(url, timeout=15)
+        index_html = _get_text(base_url, timeout)
     except requests.RequestException as e:
-        print(f"  [{service}] Request error: {e}")
-        return set(), False
+        raise RuntimeError(f"Could not discover services from official Yandex docs: {e}") from e
 
-    if resp.status_code == 404:
-        return set(), False
-    if not resp.ok:
-        print(f"  [{service}] HTTP {resp.status_code}")
-        return set(), False
+    service_links = parse_v5_service_links(index_html, base_url)
+    if not service_links:
+        raise RuntimeError("Could not discover services from official Yandex docs: no service links found")
 
+    print(f"  Found {len(service_links)} seed service page(s).", file=sys.stderr)
+    services: list[DiscoveredService] = []
+    queued = deque(service_links)
+    seen_links = set(service_links)
+    processed_links: set[str] = set()
+
+    while queued:
+        link = queued.popleft()
+        if link in processed_links:
+            continue
+        processed_links.add(link)
+        try:
+            page_html = _get_text(link, timeout)
+        except requests.RequestException as e:
+            print(f"  Warning: could not fetch service page {link}: {e}", file=sys.stderr)
+            continue
+
+        for discovered_link in parse_v5_service_links(page_html, base_url):
+            if discovered_link not in seen_links:
+                seen_links.add(discovered_link)
+                queued.append(discovered_link)
+
+        parsed = parse_v5_service_page(page_html, link)
+        services.extend(parsed)
+        print(f"  [{link}] {len(parsed)} WSDL URL(s)", file=sys.stderr)
+
+    if not services:
+        raise RuntimeError("Could not discover services from official Yandex docs: no WSDL URLs found")
+
+    # Deduplicate by (version, endpoint), keeping the first occurrence (canonical page)
+    seen: set[tuple[str, str]] = set()
+    deduped: list[DiscoveredService] = []
+    for svc in services:
+        key = (svc.version, svc.endpoint)
+        if key not in seen:
+            seen.add(key)
+            deduped.append(svc)
+    return deduped
+
+
+def discover_v4_methods_from_docs(base_url: str, timeout: int) -> list[LegacyMethod]:
+    """Load official Yandex Direct v4 docs and extract legacy method records."""
+    print(f"Fetching official Yandex Direct v4 docs index: {base_url} ...", file=sys.stderr)
     try:
-        root = ET.fromstring(resp.content)
-    except ET.ParseError as e:
-        print(f"  [{service}] XML parse error: {e}")
-        return set(), False
+        index_html = _get_text(base_url, timeout)
+    except requests.RequestException as e:
+        print(f"  Warning: could not fetch v4 docs: {e}", file=sys.stderr)
+        return []
 
+    methods = parse_v4_method_links(index_html, base_url)
+    all_methods_url = _normalize_docs_url("en/reference/_AllMethods", base_url)
+    try:
+        all_methods_html = _get_text(all_methods_url, timeout)
+    except requests.RequestException as e:
+        print(f"  Warning: could not fetch v4 methods page {all_methods_url}: {e}", file=sys.stderr)
+    else:
+        known = {method.docs_url for method in methods}
+        for method in parse_v4_method_links(all_methods_html, base_url):
+            if method.docs_url not in known:
+                methods.append(method)
+                known.add(method.docs_url)
+
+    print(f"  Found {len(methods)} v4 method links.", file=sys.stderr)
+    return methods
+
+
+def parse_wsdl_operations(content: bytes) -> set[str]:
+    root = ET.fromstring(content)
     operations: set[str] = set()
     for pt in root.findall(f"{{{WSDL_NS}}}portType"):
         for op in pt.findall(f"{{{WSDL_NS}}}operation"):
             name = op.get("name")
             if name:
                 operations.add(name)
+    return operations
+
+
+def fetch_wsdl_operations(wsdl_url: str, timeout: int = 15) -> tuple[set[str], bool]:
+    """Fetch WSDL URL and extract operation names from portType."""
+    try:
+        resp = requests.get(wsdl_url, timeout=timeout)
+    except requests.RequestException as e:
+        print(f"  [{wsdl_url}] Request error: {e}", file=sys.stderr)
+        return set(), False
+
+    if resp.status_code == 404:
+        return set(), False
+    if not resp.ok:
+        print(f"  [{wsdl_url}] HTTP {resp.status_code}", file=sys.stderr)
+        return set(), False
+
+    try:
+        operations = parse_wsdl_operations(resp.content)
+    except ET.ParseError as e:
+        print(f"  [{wsdl_url}] XML parse error: {e}", file=sys.stderr)
+        return set(), False
 
     return operations, True
 
 
-def build_report(
-    discovered_services: list[str],
+def _library_entry(endpoint: str) -> tuple[str, dict] | None:
+    return next(
+        ((name, info) for name, info in WSDL_RESOURCES.items() if info["endpoint"] == endpoint),
+        None,
+    )
+
+
+def _coverage_rows(
+    version: str,
+    discovered_services: list[DiscoveredService],
     wsdl_results: dict[str, tuple[set[str], bool]],
-) -> str:
-    today = date.today().isoformat()
-
-    # All endpoints confirmed via WSDL response
-    wsdl_endpoints = {name: info for name, info in WSDL_RESOURCES.items()}
-    library_endpoints = {info["endpoint"] for info in wsdl_endpoints.values()}
-
-    all_candidates = set(discovered_services) | library_endpoints
-    confirmed_endpoints = {
-        ep for ep in all_candidates
-        if wsdl_results.get(ep, (set(), False))[1]
+) -> list[dict]:
+    services_by_endpoint = {
+        service.endpoint: service
+        for service in discovered_services
+        if service.version == version
     }
-
-    # Missing: confirmed via WSDL but not in library
-    missing_endpoints = confirmed_endpoints - library_endpoints
-    # Extra: in library but WSDL unavailable
-    extra_endpoints = library_endpoints - confirmed_endpoints
-
-    # Build per-resource diff table
-    # All resources: library wsdl resources + missing (new API services)
-    all_resource_endpoints = library_endpoints | missing_endpoints
+    library_endpoints = {info["endpoint"] for info in WSDL_RESOURCES.values()}
+    all_endpoints = sorted(set(services_by_endpoint) | library_endpoints)
 
     rows: list[dict] = []
-    for ep in sorted(all_resource_endpoints):
-        wsdl_ops, available = wsdl_results.get(ep, (set(), False))
-
-        # Find library entry by endpoint
-        lib_entry = next(
-            ((name, info) for name, info in WSDL_RESOURCES.items()
-             if info["endpoint"] == ep),
-            None,
-        )
+    for endpoint in all_endpoints:
+        service = services_by_endpoint.get(endpoint)
+        lib_entry = _library_entry(endpoint)
 
         if lib_entry:
             lib_name, lib_info = lib_entry
@@ -188,54 +449,137 @@ def build_report(
             lib_name = None
             lib_methods = set()
 
+        if service:
+            wsdl_ops, available = wsdl_results.get(service.wsdl_url, (set(), False))
+            official_methods = wsdl_ops if available else service.methods
+        else:
+            wsdl_ops, available = set(), False
+            official_methods = set()
+
         pseudo = KNOWN_NON_WSDL_METHODS.get(lib_name, set()) if lib_name else set()
-        missing_methods = (wsdl_ops - lib_methods - pseudo) if available else set()
-        extra_methods = lib_methods - wsdl_ops if available else set()
-        status = "ok" if available and not missing_methods else ("no_wsdl" if not available else "gap")
+        missing_methods = official_methods - lib_methods - pseudo
+        extra_methods = lib_methods - official_methods if available else set()
+        doc_wsdl_mismatch = service.methods ^ wsdl_ops if service and available else set()
 
         rows.append({
-            "endpoint": ep,
+            "endpoint": endpoint,
+            "service": service,
             "lib_name": lib_name,
             "lib_methods": lib_methods,
             "wsdl_ops": wsdl_ops,
+            "official_methods": official_methods,
             "available": available,
             "missing_methods": missing_methods,
             "extra_methods": extra_methods,
-            "status": status,
+            "doc_wsdl_mismatch": doc_wsdl_mismatch,
             "in_library": lib_entry is not None,
+            "in_docs": service is not None,
         })
+
+    return rows
+
+
+def _append_coverage_section(lines: list[str], version: str, rows: list[dict]) -> None:
+    official_count = sum(1 for row in rows if row["in_docs"])
+    missing_services = sum(1 for row in rows if row["in_docs"] and not row["in_library"])
+    extra_services = sum(1 for row in rows if row["in_library"] and not row["in_docs"])
+    gap_services = sum(1 for row in rows if row["missing_methods"])
+    missing_methods = sum(len(row["missing_methods"]) for row in rows)
+
+    lines += [
+        f"## {version} Coverage",
+        "",
+        "| Category | Count |",
+        "|---|---|",
+        f"| Official docs services | {official_count} |",
+        f"| Missing services (in live API, not in library) | {missing_services} |",
+        f"| Extra services (in library, not in live API docs) | {extra_services} |",
+        f"| Services with missing methods | {gap_services} |",
+        f"| Total missing methods | {missing_methods} |",
+        "",
+    ]
+
+    for i, row in enumerate(rows, start=1):
+        service = row["service"]
+        endpoint = row["endpoint"]
+        lib_name = row["lib_name"] or "_(not in library)_"
+
+        if row["in_docs"] and not row["in_library"]:
+            status_label = "NEW - not in library"
+        elif row["in_library"] and not row["in_docs"]:
+            status_label = "not in official docs"
+        elif not row["available"]:
+            status_label = "WSDL unavailable"
+        elif row["missing_methods"]:
+            status_label = "method gap"
+        else:
+            status_label = "ok"
+
+        lines.append(f"### {i}. `{endpoint}` (lib: `{lib_name}`) - {status_label}")
+        lines.append("")
+        if service:
+            lines.append(f"- **Docs:** {service.docs_url}")
+            lines.append(f"- **WSDL:** {service.wsdl_url}")
+            if service.soap_url:
+                lines.append(f"- **SOAP:** {service.soap_url}")
+            if service.json_url:
+                lines.append(f"- **JSON:** {service.json_url}")
+            if service.methods:
+                lines.append(f"- **Official docs methods ({len(service.methods)}):** `{'`, `'.join(sorted(service.methods))}`")
+        else:
+            lines.append("- **Docs:** not found in official live docs")
+
+        if row["available"]:
+            lines.append(f"- **WSDL operations ({len(row['wsdl_ops'])}):** `{'`, `'.join(sorted(row['wsdl_ops']))}`")
+        elif service:
+            lines.append("- **WSDL operations:** unavailable")
+
+        if row["lib_methods"]:
+            lines.append(f"- **Library declared ({len(row['lib_methods'])}):** `{'`, `'.join(sorted(row['lib_methods']))}`")
+        else:
+            lines.append("- **Library declared:** none")
+
+        if row["missing_methods"]:
+            lines.append(f"- **Missing in library ({len(row['missing_methods'])}):** `{'`, `'.join(sorted(row['missing_methods']))}`")
+        if row["extra_methods"]:
+            lines.append(f"- **In library but not in live API ({len(row['extra_methods'])}):** `{'`, `'.join(sorted(row['extra_methods']))}`")
+        if row["doc_wsdl_mismatch"]:
+            lines.append(f"- **Docs/WSDL mismatch ({len(row['doc_wsdl_mismatch'])}):** `{'`, `'.join(sorted(row['doc_wsdl_mismatch']))}`")
+        lines.append("")
+
+
+def build_report(
+    discovered_services: list[DiscoveredService],
+    wsdl_results: dict[str, tuple[set[str], bool]],
+    legacy_methods: list[LegacyMethod] | None = None,
+) -> str:
+    today = date.today().isoformat()
+    legacy_methods = legacy_methods or []
+    versions = sorted({service.version for service in discovered_services}, key=lambda v: (v != "v5", v))
 
     n_total_lib = len(RESOURCE_CATALOG)
     n_wsdl_lib = len(WSDL_RESOURCES)
     n_reports = sum(1 for i in RESOURCE_CATALOG.values() if i["type"] == "reports")
     n_oauth = sum(1 for i in RESOURCE_CATALOG.values() if i["type"] == "oauth")
-    n_confirmed = len(confirmed_endpoints)
-    n_missing_svc = len(missing_endpoints)
-    n_extra_svc = len(extra_endpoints)
-    n_gap_methods = sum(1 for r in rows if r["missing_methods"])
-    n_total_missing_methods = sum(len(r["missing_methods"]) for r in rows)
 
     lines = [
-        "# Yandex Direct API v5 — WSDL Audit Report",
+        "# Yandex Direct API - Official Docs WSDL/SOAP Audit Report",
         f"**Date:** {today}",
         "",
         "## Summary",
         "",
-        f"| Category | Count |",
-        f"|---|---|",
+        "| Category | Count |",
+        "|---|---|",
         f"| Total resources in `resource_mapping.py` | {n_total_lib} |",
         f"| — SOAP/WSDL services | {n_wsdl_lib} |",
         f"| — Reports API (non-SOAP) | {n_reports} |",
         f"| — OAuth helpers | {n_oauth} |",
-        f"| WSDL-confirmed API services (live check) | {n_confirmed} |",
-        f"| Missing services (in API, not in library) | {n_missing_svc} |",
-        f"| Extra services (in library, WSDL unavailable) | {n_extra_svc} |",
-        f"| Services with missing methods | {n_gap_methods} |",
-        f"| Total missing methods | {n_total_missing_methods} |",
+        f"| Official docs versions | {', '.join(versions) if versions else 'none'} |",
+        f"| Official docs WSDL entries | {len(discovered_services)} |",
+        f"| Legacy v4 methods | {len(legacy_methods)} |",
         "",
     ]
 
-    # Non-WSDL resources explanation
     lines += [
         "## Non-WSDL Resources",
         "",
@@ -245,59 +589,22 @@ def build_report(
     for i, (name, info) in enumerate(
         ((n, i) for n, i in RESOURCE_CATALOG.items() if i["type"] != "wsdl"), start=1
     ):
-        type_label = {"reports": "Reports API (TSV, async)", "oauth": "OAuth helper"}[info["type"]]
+        type_label = {"reports": "Reports API (TSV, async)", "oauth": "OAuth helper"}.get(info["type"], info["type"])
         lines.append(f"{i}. **{name}** (`{info['endpoint']}`) — {type_label}")
     lines.append("")
 
-    # Full per-resource diff
-    lines += [
-        "## Full Resource Diff",
-        "",
-        "Every SOAP/WSDL resource with its method coverage.",
-        "",
-    ]
+    for version in versions:
+        _append_coverage_section(lines, version, _coverage_rows(version, discovered_services, wsdl_results))
 
-    for i, row in enumerate(rows, start=1):
-        ep = row["endpoint"]
-        lib_name = row["lib_name"] or "_(not in library)_"
-        available = row["available"]
-        wsdl_ops = row["wsdl_ops"]
-        lib_methods = row["lib_methods"]
-        missing_methods = row["missing_methods"]
-        extra_methods = row["extra_methods"]
-
-        if not row["in_library"]:
-            status_icon = "🆕"
-            status_label = "NEW — not in library"
-        elif not available:
-            status_icon = "❓"
-            status_label = "WSDL unavailable"
-        elif missing_methods:
-            status_icon = "⚠️"
-            status_label = "method gap"
-        else:
-            status_icon = "✅"
-            status_label = "ok"
-
-        lines.append(f"### {i}. `{ep}` (lib: `{lib_name}`) {status_icon} {status_label}")
-        lines.append("")
-
-        if available:
-            lines.append(f"- **WSDL operations ({len(wsdl_ops)}):** `{'`, `'.join(sorted(wsdl_ops))}`")
-        else:
-            lines.append("- **WSDL:** not available")
-
-        if lib_methods:
-            lines.append(f"- **Library declared ({len(lib_methods)}):** `{'`, `'.join(sorted(lib_methods))}`")
-        else:
-            lines.append("- **Library declared:** none")
-
-        if missing_methods:
-            lines.append(f"- **Missing in library ({len(missing_methods)}):** `{'`, `'.join(sorted(missing_methods))}`")
-
-        if extra_methods:
-            lines.append(f"- **In library but not in WSDL ({len(extra_methods)}):** `{'`, `'.join(sorted(extra_methods))}`")
-
+    if legacy_methods:
+        lines += [
+            "## v4 Legacy SOAP/WSDL",
+            "",
+            "These methods come from the official legacy Direct API v4 documentation and are reported separately from v5 resource coverage.",
+            "",
+        ]
+        for i, method in enumerate(legacy_methods, start=1):
+            lines.append(f"{i}. **{method.name}** — {method.docs_url}")
         lines.append("")
 
     return "\n".join(lines)
@@ -307,18 +614,31 @@ def create_github_issue(report: str) -> None:
     today = date.today().isoformat()
     title = f"WSDL Audit: API coverage gaps {today}"
 
+    tmp_path = None
     try:
+        with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False, encoding="utf-8") as tmp:
+            tmp.write(report)
+            tmp_path = tmp.name
         result = subprocess.run(
-            ["gh", "issue", "create", "--title", title, "--body", report],
-            capture_output=True, text=True, check=True,
+            ["gh", "issue", "create", "--title", title, "--body-file", tmp_path],
+            capture_output=True, text=True, check=True, timeout=60,
         )
-        print(f"\nGitHub issue created: {result.stdout.strip()}")
+        print(f"\nGitHub issue created: {result.stdout.strip()}", file=sys.stderr)
     except FileNotFoundError:
-        print("\nError: 'gh' CLI not found. Install it from https://cli.github.com/")
+        print("\nError: 'gh' CLI not found. Install it from https://cli.github.com/", file=sys.stderr)
         sys.exit(1)
     except subprocess.CalledProcessError as e:
-        print(f"\nError creating GitHub issue:\n{e.stderr}")
+        print(f"\nError creating GitHub issue:\n{e.stderr}", file=sys.stderr)
         sys.exit(1)
+    except subprocess.TimeoutExpired:
+        print("\nError: gh CLI timed out after 60 seconds.", file=sys.stderr)
+        sys.exit(1)
+    finally:
+        if tmp_path:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
 
 
 def main() -> None:
@@ -327,32 +647,55 @@ def main() -> None:
                         help="Create a GitHub issue with the report (requires gh CLI)")
     parser.add_argument("--output", metavar="FILE",
                         help="Save report to file instead of printing to stdout")
+    parser.add_argument("--versions", default="v5,v501,v4",
+                        help="Comma-separated versions to audit: v5,v501,v4")
+    parser.add_argument("--docs-base-url", default=DOCS_BASE_URL,
+                        help="Official Yandex Direct v5 documentation base URL")
+    parser.add_argument("--v4-docs-base-url", default=V4_DOCS_BASE_URL,
+                        help="Official Yandex Direct v4 documentation base URL")
+    parser.add_argument("--timeout", type=int, default=15,
+                        help="HTTP timeout in seconds")
     args = parser.parse_args()
 
-    api_services = discover_services_from_github()
+    requested_versions = {version.strip() for version in args.versions.split(",") if version.strip()}
+    supported_versions = {"v5", "v501", "v4"}
+    unsupported = requested_versions - supported_versions
+    if unsupported:
+        parser.error(f"unsupported version(s): {', '.join(sorted(unsupported))}")
 
-    # Fetch WSDL for all candidates: discovered + library endpoints
-    library_endpoints = {info["endpoint"] for info in WSDL_RESOURCES.values()}
-    all_services = sorted(set(api_services) | library_endpoints)
+    discovered_services: list[DiscoveredService] = []
+    legacy_methods: list[LegacyMethod] = []
+
+    if requested_versions & {"v5", "v501"}:
+        discovered_services = [
+            service for service in discover_v5_services_from_docs(args.docs_base_url, args.timeout)
+            if service.version in requested_versions
+        ]
+
+    if "v4" in requested_versions:
+        legacy_methods = discover_v4_methods_from_docs(args.v4_docs_base_url, args.timeout)
 
     wsdl_results: dict[str, tuple[set[str], bool]] = {}
-    print(f"\nFetching WSDL for {len(all_services)} services...")
-    for service in all_services:
-        ops, available = fetch_wsdl_operations(service)
-        wsdl_results[service] = (ops, available)
-        status = (
-            f"{len(ops)} operations: {', '.join(sorted(ops))}"
-            if available else "WSDL not available"
-        )
-        print(f"  [{service}] {status}")
+    seen_wsdl: set[str] = set()
+    print(f"\nFetching WSDL for {len(discovered_services)} official docs entries...", file=sys.stderr)
+    for service in discovered_services:
+        if service.wsdl_url not in seen_wsdl:
+            seen_wsdl.add(service.wsdl_url)
+            ops, available = fetch_wsdl_operations(service.wsdl_url, args.timeout)
+            wsdl_results[service.wsdl_url] = (ops, available)
+            status = (
+                f"{len(ops)} operations: {', '.join(sorted(ops))}"
+                if available else "WSDL not available"
+            )
+            print(f"  [{service.version}/{service.endpoint}] {status}", file=sys.stderr)
 
-    print("\nBuilding report...")
-    report = build_report(api_services, wsdl_results)
+    print("\nBuilding report...", file=sys.stderr)
+    report = build_report(discovered_services, wsdl_results, legacy_methods)
 
     if args.output:
         with open(args.output, "w", encoding="utf-8") as f:
             f.write(report)
-        print(f"Report saved to {args.output}")
+        print(f"Report saved to {args.output}", file=sys.stderr)
     else:
         print(report)
 

--- a/tests/test_audit_wsdl.py
+++ b/tests/test_audit_wsdl.py
@@ -1,0 +1,277 @@
+import importlib.util
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "audit_wsdl.py"
+spec = importlib.util.spec_from_file_location("audit_wsdl", MODULE_PATH)
+audit_wsdl = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(audit_wsdl)
+
+
+def test_parse_v5_service_page_extracts_methods_and_transport_urls():
+    html = """
+    <html>
+      <body>
+        <h1>AdExtensions: operations with ad extensions</h1>
+        <p>Methods <a>add</a> | <a>get</a> | <a>delete</a></p>
+        <p>WSDL description address</p>
+        <code>https://api.direct.yandex.com/v5/adextensions?wsdl</code>
+        <code>https://api.direct.yandex.com/v501/adextensions?wsdl</code>
+        <p>SOAP address</p>
+        <code>https://api.direct.yandex.com/v5/adextensions</code>
+        <p>JSON address</p>
+        <code>https://api.direct.yandex.com/json/v5/adextensions</code>
+      </body>
+    </html>
+    """
+
+    services = audit_wsdl.parse_v5_service_page(
+        html,
+        "https://yandex.com/dev/direct/doc/en/adextensions/adextensions",
+    )
+
+    assert [service.version for service in services] == ["v5", "v501"]
+    assert services[0].name == "AdExtensions"
+    assert services[0].endpoint == "adextensions"
+    assert services[0].methods == {"add", "get", "delete"}
+    assert services[0].wsdl_url == "https://api.direct.yandex.com/v5/adextensions?wsdl"
+    assert services[0].soap_url == "https://api.direct.yandex.com/v5/adextensions"
+    assert services[0].json_url == "https://api.direct.yandex.com/json/v5/adextensions"
+
+
+def test_parse_v5_service_page_extracts_methods_from_service_method_links():
+    html = """
+    <html>
+      <body>
+        <h1>Strategies: operations with portfolio strategies</h1>
+        <a href="en/strategies/strategies">Strategies: operations with portfolio strategies</a>
+        <a href="en/strategies/add">add</a>
+        <a href="en/strategies/archive">archive</a>
+        <a href="en/strategies/get">get</a>
+        <a href="en/strategies/unarchive">unarchive</a>
+        <a href="en/strategies/update">update</a>
+        <a href="https://api.direct.yandex.com/v5/strategies?wsdl">v5 WSDL</a>
+        <a href="https://api.direct.yandex.com/v501/strategies?wsdl">v501 WSDL</a>
+        <a href="https://api.direct.yandex.com/v5/strategies">v5 SOAP</a>
+        <a href="https://api.direct.yandex.com/json/v5/strategies">v5 JSON</a>
+      </body>
+    </html>
+    """
+
+    services = audit_wsdl.parse_v5_service_page(
+        html,
+        "https://yandex.com/dev/direct/doc/en/strategies/strategies",
+    )
+
+    assert [service.version for service in services] == ["v5", "v501"]
+    assert services[0].endpoint == "strategies"
+    assert services[0].methods == {"add", "archive", "get", "unarchive", "update"}
+    assert services[0].wsdl_url == "https://api.direct.yandex.com/v5/strategies?wsdl"
+    assert services[0].soap_url == "https://api.direct.yandex.com/v5/strategies"
+    assert services[0].json_url == "https://api.direct.yandex.com/json/v5/strategies"
+
+
+def test_parse_v5_service_page_extracts_single_method_from_links():
+    html = """
+    <html>
+      <body>
+        <h1>TurboPages: getting parameters of Turbo pages</h1>
+        <a href="en/turbopages/turbopages">TurboPages: getting parameters of Turbo pages</a>
+        <a href="en/turbopages/get">get</a>
+        <a href="https://api.direct.yandex.com/v5/turbopages?wsdl">v5 WSDL</a>
+      </body>
+    </html>
+    """
+
+    services = audit_wsdl.parse_v5_service_page(
+        html,
+        "https://yandex.com/dev/direct/doc/en/turbopages/turbopages",
+    )
+
+    assert services[0].endpoint == "turbopages"
+    assert services[0].methods == {"get"}
+
+
+def test_parse_v5_index_extracts_service_page_links_only():
+    html = """
+    <a href="en/adgroups/adgroups">AdGroups</a>
+    <a href="en/adgroups/adgroups#methods">AdGroups methods</a>
+    <a href="/dev/direct/doc/en/adextensions/adextensions">AdExtensions</a>
+    <a href="/dev/direct/doc/en/concepts/soap">SOAP protocol</a>
+    <a href="/dev/direct/doc/en/campaigns/campaigns">Campaigns</a>
+    <a href="/dev/direct/doc/en/reports/reports">Reports</a>
+    """
+
+    links = audit_wsdl.parse_v5_service_links(
+        html,
+        "https://yandex.com/dev/direct/doc/en/",
+    )
+
+    assert links == [
+        "https://yandex.com/dev/direct/doc/en/adgroups/adgroups",
+        "https://yandex.com/dev/direct/doc/en/adextensions/adextensions",
+        "https://yandex.com/dev/direct/doc/en/campaigns/campaigns",
+        "https://yandex.com/dev/direct/doc/en/reports/reports",
+    ]
+
+
+def test_parse_v4_index_extracts_legacy_method_links():
+    html = """
+    <a href="en/reference/_AllMethods">Methods</a>
+    <a href="en/reference/ErrorCodes">ErrorCodes</a>
+    <a href="en/reference/GetAvailableVersions">GetAvailableVersions</a>
+    <a href="en/live/GetEventsLog">GetEventsLog (Live)</a>
+    <a href="/dev/direct/doc/dg-v4/en/reference/CreateNewWordstatReport">CreateNewWordstatReport</a>
+    <a href="/dev/direct/doc/dg-v4/en/reference/GetWordstatReport">GetWordstatReport</a>
+    <a href="/dev/direct/doc/dg-v4/en/concepts/access">Access</a>
+    """
+
+    methods = audit_wsdl.parse_v4_method_links(
+        html,
+        "https://yandex.com/dev/direct/doc/dg-v4/en/",
+    )
+
+    assert methods == [
+        audit_wsdl.LegacyMethod(
+            name="GetAvailableVersions",
+            docs_url="https://yandex.com/dev/direct/doc/dg-v4/en/reference/GetAvailableVersions",
+        ),
+        audit_wsdl.LegacyMethod(
+            name="GetEventsLog (Live)",
+            docs_url="https://yandex.com/dev/direct/doc/dg-v4/en/live/GetEventsLog",
+        ),
+        audit_wsdl.LegacyMethod(
+            name="CreateNewWordstatReport",
+            docs_url="https://yandex.com/dev/direct/doc/dg-v4/en/reference/CreateNewWordstatReport",
+        ),
+        audit_wsdl.LegacyMethod(
+            name="GetWordstatReport",
+            docs_url="https://yandex.com/dev/direct/doc/dg-v4/en/reference/GetWordstatReport",
+        ),
+    ]
+
+
+def test_parse_wsdl_operations_extracts_port_type_operations():
+    xml = """
+    <definitions xmlns="http://schemas.xmlsoap.org/wsdl/">
+      <portType name="AdExtensionsPort">
+        <operation name="add" />
+        <operation name="get" />
+      </portType>
+    </definitions>
+    """
+
+    assert audit_wsdl.parse_wsdl_operations(xml.encode()) == {"add", "get"}
+
+
+def test_discover_v5_services_expands_service_links_from_fetched_pages(monkeypatch):
+    pages = {
+        "https://yandex.com/dev/direct/doc/en/": """
+            <a href="en/adextensions/adextensions">AdExtensions</a>
+        """,
+        "https://yandex.com/dev/direct/doc/en/adextensions/adextensions": """
+            <h1>AdExtensions: operations with ad extensions</h1>
+            <a href="en/adgroups/adgroups">AdGroups</a>
+            <p>Methods: <a>add</a> | <a>get</a> | <a>delete</a></p>
+            <code>https://api.direct.yandex.com/v5/adextensions?wsdl</code>
+            <code>https://api.direct.yandex.com/v5/adextensions</code>
+            <code>https://api.direct.yandex.com/json/v5/adextensions</code>
+        """,
+        "https://yandex.com/dev/direct/doc/en/adgroups/adgroups": """
+            <h1>AdGroups: operations with ad groups</h1>
+            <p>Methods: <a>add</a> | <a>get</a> | <a>update</a> | <a>delete</a></p>
+            <code>https://api.direct.yandex.com/v5/adgroups?wsdl</code>
+            <code>https://api.direct.yandex.com/v5/adgroups</code>
+            <code>https://api.direct.yandex.com/json/v5/adgroups</code>
+        """,
+    }
+
+    def fake_get_text(url, timeout):
+        return pages[url]
+
+    monkeypatch.setattr(audit_wsdl, "_get_text", fake_get_text)
+
+    services = audit_wsdl.discover_v5_services_from_docs(
+        "https://yandex.com/dev/direct/doc/en/",
+        timeout=1,
+    )
+
+    assert [service.endpoint for service in services] == ["adextensions", "adgroups"]
+
+
+def test_discover_v4_methods_follows_all_methods_page(monkeypatch):
+    pages = {
+        "https://yandex.com/dev/direct/doc/dg-v4/en/": """
+            <a href="en/reference/_AllMethods">Methods</a>
+        """,
+        "https://yandex.com/dev/direct/doc/dg-v4/en/reference/_AllMethods": """
+            <a href="en/reference/CreateNewWordstatReport">CreateNewWordstatReport</a>
+            <a href="en/live/GetEventsLog">GetEventsLog (Live)</a>
+        """,
+    }
+
+    def fake_get_text(url, timeout):
+        return pages[url]
+
+    monkeypatch.setattr(audit_wsdl, "_get_text", fake_get_text)
+
+    methods = audit_wsdl.discover_v4_methods_from_docs(
+        "https://yandex.com/dev/direct/doc/dg-v4/en/",
+        timeout=1,
+    )
+
+    assert methods == [
+        audit_wsdl.LegacyMethod(
+            name="CreateNewWordstatReport",
+            docs_url="https://yandex.com/dev/direct/doc/dg-v4/en/reference/CreateNewWordstatReport",
+        ),
+        audit_wsdl.LegacyMethod(
+            name="GetEventsLog (Live)",
+            docs_url="https://yandex.com/dev/direct/doc/dg-v4/en/live/GetEventsLog",
+        ),
+    ]
+
+
+def test_build_report_separates_v5_v501_and_v4_coverage():
+    discovered = [
+        audit_wsdl.DiscoveredService(
+            version="v5",
+            name="AdExtensions",
+            endpoint="adextensions",
+            docs_url="https://yandex.com/dev/direct/doc/en/adextensions/adextensions",
+            methods={"add", "get", "delete", "archive"},
+            wsdl_url="https://api.direct.yandex.com/v5/adextensions?wsdl",
+            soap_url="https://api.direct.yandex.com/v5/adextensions",
+            json_url="https://api.direct.yandex.com/json/v5/adextensions",
+        ),
+        audit_wsdl.DiscoveredService(
+            version="v501",
+            name="AdExtensions",
+            endpoint="adextensions",
+            docs_url="https://yandex.com/dev/direct/doc/en/adextensions/adextensions",
+            methods={"add", "get", "delete", "archive", "newMethod"},
+            wsdl_url="https://api.direct.yandex.com/v501/adextensions?wsdl",
+            soap_url="https://api.direct.yandex.com/v501/adextensions",
+            json_url=None,
+        ),
+    ]
+    wsdl_results = {
+        "https://api.direct.yandex.com/v5/adextensions?wsdl": ({"add", "get", "delete", "archive"}, True),
+        "https://api.direct.yandex.com/v501/adextensions?wsdl": ({"add", "get", "delete", "archive", "newMethod"}, True),
+    }
+    legacy = [
+        audit_wsdl.LegacyMethod(
+            name="CreateNewWordstatReport",
+            docs_url="https://yandex.com/dev/direct/doc/dg-v4/en/reference/CreateNewWordstatReport",
+        )
+    ]
+
+    report = audit_wsdl.build_report(discovered, wsdl_results, legacy)
+
+    assert "## v5 Coverage" in report
+    assert "## v501 Coverage" in report
+    assert "## v4 Legacy SOAP/WSDL" in report
+    assert "Official docs services | 1" in report
+    assert "Missing in library (1):** `archive`" in report
+    assert "newMethod" in report
+    assert "CreateNewWordstatReport" in report


### PR DESCRIPTION
## Summary

- Replaces GitHub repo discovery with official Yandex docs scraping (v5, v501, v4)
- Routes all progress output to stderr; report to stdout (safe for piping)
- Handles rate limits (403/429) explicitly
- Deduplicates WSDL fetches and discovered services by (version, endpoint)
- Uses `deque` for O(1) BFS queue operations
- Adds `subprocess timeout=60` for `gh issue create`
- Guards `os.unlink` in `finally` against `OSError`
- Adds `KNOWN_NON_WSDL_METHODS` to suppress false positives (e.g. `dictionaries.getGeoRegions`)
- Adds regression tests for `strategies`, `turbopages`, `agencyclients`

## Usage

```bash
python scripts/audit_wsdl.py
python scripts/audit_wsdl.py --output report.md
python scripts/audit_wsdl.py --versions v5,v501,v4
python scripts/audit_wsdl.py --issue
```