### PR TITLE
fix(docs): replace broken Yandex documentation URLs

### DIFF
--- a/scripts/yandex_direct_export_to_file.py
+++ b/scripts/yandex_direct_export_to_file.py
@@ -122,7 +122,7 @@ if __name__ == "__main__":
         "--token",
         required=True,
         type=str,
-        help="Access token, detail https://yandex.ru/dev/direct/doc/dg/concepts/auth-token.html",
+        help="Access token, detail https://yandex.ru/dev/direct/doc/ru/concepts/auth-token",
     )
     parser.add_argument(
         "--login",
@@ -143,8 +143,8 @@ if __name__ == "__main__":
         "--body_filepath",
         required=True,
         type=str,
-        help="Request body, detail https://yandex.ru/dev/direct/doc/dg/concepts/JSON.html#JSON__json-request "
-             "and https://yandex.ru/dev/direct/doc/reports/spec.html",
+        help="Request body, detail https://yandex.ru/dev/direct/doc/ru/concepts/JSON "
+             "and https://yandex.ru/dev/direct/doc/ru/spec",
     )
     parser.add_argument(
         "--filepath",
@@ -156,14 +156,14 @@ if __name__ == "__main__":
         "--use_operator_units",
         required=False,
         type=bool,
-        help="HTTP-header, detail https://yandex.ru/dev/direct/doc/reports/headers.html",
+        help="HTTP-header, detail https://yandex.ru/dev/direct/doc/ru/headers",
         default=False,
     )
     parser.add_argument(
         "--return_money_in_micros",
         required=False,
         type=bool,
-        help="HTTP-header, detail https://yandex.ru/dev/direct/doc/reports/headers.html",
+        help="HTTP-header, detail https://yandex.ru/dev/direct/doc/ru/headers",
         default=False,
     )
     parser.add_argument(

--- a/tapi_yandex_direct/resource_mapping.py
+++ b/tapi_yandex_direct/resource_mapping.py
@@ -106,7 +106,7 @@ RESOURCE_MAPPING_V5 = {
     },
     "debugtoken": {
         "resource": "oauth.yandex.ru/authorize?response_type=token&client_id={client_id}",
-        "docs": "https://yandex.ru/dev/direct/doc/ru/dg/concepts/auth-token",
+        "docs": "https://yandex.ru/dev/direct/doc/ru/concepts/auth-token",
     },
     "feeds": {
         "resource": "json/v5/feeds",

--- a/tests/test_resource_mapping.py
+++ b/tests/test_resource_mapping.py
@@ -1,0 +1,7 @@
+from tapi_yandex_direct.resource_mapping import RESOURCE_MAPPING_V5
+
+
+def test_no_legacy_docs_paths():
+    for name, info in RESOURCE_MAPPING_V5.items():
+        assert "/dg/concepts/" not in info["docs"], f"{name}: legacy /dg/concepts/ URL"
+        assert ".html" not in info["docs"], f"{name}: legacy .html suffix"


### PR DESCRIPTION
## Summary

Fix broken Yandex Direct documentation URLs that return 404 or redirect to captcha.

Yandex restructured their documentation site:
- old: `/dev/direct/doc/dg/concepts/...`
- new: `/dev/direct/doc/ru/concepts/...`

Also dropped `.html` suffixes and renamed `reports/spec.html` → `ru/spec`, `reports/headers.html` → `ru/headers`.

## Changes

- `tapi_yandex_direct/resource_mapping.py:109` — fix `debugtoken` auth-token URL
- `scripts/yandex_direct_export_to_file.py` — fix 5 URLs in argparse help strings (auth-token, JSON spec, reports spec, headers x2)
- `tests/test_resource_mapping.py` (new) — regression guard against legacy `/dg/concepts/` and `.html` paths

## Test plan

- [x] `pytest tests/` — all 10 tests pass
- [x] All replaced URLs verified via curl to return 200 OK

Closes #9