### PR TITLE
feat(audit): WSDL coverage and v4↔v5 matrix for legacy API

### DIFF
--- a/docs/v4_methods_matrix.md
+++ b/docs/v4_methods_matrix.md
@@ -18,11 +18,11 @@ Status semantics:
 | Operations also available in v4 Live only | 17 |
 | Operations available in both v4 and Live | 57 |
 | Operations available only in v4 (not Live) | 0 |
-| Status: deprecated_with_v5_replacement | 42 |
-| Status: actual_no_v5_analogue (candidates) | 32 |
+| Status: deprecated_with_v5_replacement | 41 |
+| Status: actual_no_v5_analogue (candidates) | 33 |
 | Status: unclassified (needs review) | 0 |
 | Priority: high (issue-mentioned candidates) | 20 |
-| Priority: medium (other actual candidates) | 12 |
+| Priority: medium (other actual candidates) | 9 |
 
 ## Full method table
 
@@ -49,7 +49,7 @@ Status semantics:
 | 19 | `DeleteReport` | v4 + Live | actual_no_v5_analogue | — | medium |
 | 20 | `DeleteWordstatReport` | v4 + Live | actual_no_v5_analogue | — | high |
 | 21 | `EnableSharedAccount` | Live only | actual_no_v5_analogue | — | high |
-| 22 | `GetAvailableVersions` | v4 + Live | actual_no_v5_analogue | — | medium |
+| 22 | `GetAvailableVersions` | v4 + Live | actual_no_v5_analogue | — | low |
 | 23 | `GetBalance` | v4 + Live | actual_no_v5_analogue | — | high |
 | 24 | `GetBannerPhrases` | v4 + Live | deprecated_with_v5_replacement | `keywords.get` | low |
 | 25 | `GetBannerPhrasesFilter` | v4 + Live | deprecated_with_v5_replacement | `keywords.get` | low |
@@ -69,7 +69,7 @@ Status semantics:
 | 39 | `GetEventsLog` | Live only | actual_no_v5_analogue | — | high |
 | 40 | `GetForecast` | v4 + Live | actual_no_v5_analogue | — | high |
 | 41 | `GetForecastList` | v4 + Live | actual_no_v5_analogue | — | high |
-| 42 | `GetKeywordsSuggestion` | v4 + Live | deprecated_with_v5_replacement | `keywordsresearch.deduplicate` | low |
+| 42 | `GetKeywordsSuggestion` | v4 + Live | actual_no_v5_analogue | — | medium |
 | 43 | `GetOfflineReportList` | Live only | deprecated_with_v5_replacement | `reports.get` | low |
 | 44 | `GetRegions` | v4 + Live | deprecated_with_v5_replacement | `dictionaries.get` | low |
 | 45 | `GetReportList` | v4 + Live | deprecated_with_v5_replacement | `reports.get` | low |
@@ -79,15 +79,15 @@ Status semantics:
 | 49 | `GetSubClients` | v4 + Live | deprecated_with_v5_replacement | `agencyclients.get` | low |
 | 50 | `GetSummaryStat` | v4 + Live | deprecated_with_v5_replacement | `reports.get` | low |
 | 51 | `GetTimeZones` | v4 + Live | deprecated_with_v5_replacement | `dictionaries.get` | low |
-| 52 | `GetVersion` | v4 + Live | actual_no_v5_analogue | — | medium |
+| 52 | `GetVersion` | v4 + Live | actual_no_v5_analogue | — | low |
 | 53 | `GetWordstatReport` | v4 + Live | actual_no_v5_analogue | — | high |
 | 54 | `GetWordstatReportList` | v4 + Live | actual_no_v5_analogue | — | high |
 | 55 | `Keyword` | Live only | deprecated_with_v5_replacement | `keywords.add` | low |
 | 56 | `ModerateBanners` | v4 + Live | deprecated_with_v5_replacement | `ads.moderate` | low |
 | 57 | `PayCampaigns` | v4 + Live | actual_no_v5_analogue | — | high |
 | 58 | `PayCampaignsByCard` | v4 + Live | actual_no_v5_analogue | — | high |
-| 59 | `PingAPI` | v4 + Live | actual_no_v5_analogue | — | medium |
-| 60 | `PingAPI_X` | v4 + Live | actual_no_v5_analogue | — | medium |
+| 59 | `PingAPI` | v4 + Live | actual_no_v5_analogue | — | low |
+| 60 | `PingAPI_X` | v4 + Live | actual_no_v5_analogue | — | low |
 | 61 | `ResumeBanners` | v4 + Live | deprecated_with_v5_replacement | `ads.resume` | low |
 | 62 | `ResumeCampaign` | v4 + Live | deprecated_with_v5_replacement | `campaigns.resume` | low |
 | 63 | `Retargeting` | Live only | deprecated_with_v5_replacement | `retargeting.get` | low |
@@ -133,11 +133,12 @@ Methods with no v5 analogue, sorted by priority (high → medium):
 | 22 | `CheckPayment` | v4 + Live | medium |
 | 23 | `DeleteOfflineReport` | Live only | medium |
 | 24 | `DeleteReport` | v4 + Live | medium |
-| 25 | `GetAvailableVersions` | v4 + Live | medium |
+| 25 | `GetAvailableVersions` | v4 + Live | low |
 | 26 | `GetBannersTags` | Live only | medium |
 | 27 | `GetCampaignsTags` | Live only | medium |
-| 28 | `GetVersion` | v4 + Live | medium |
-| 29 | `PingAPI` | v4 + Live | medium |
-| 30 | `PingAPI_X` | v4 + Live | medium |
-| 31 | `UpdateBannersTags` | Live only | medium |
-| 32 | `UpdateCampaignsTags` | Live only | medium |
+| 28 | `GetKeywordsSuggestion` | v4 + Live | medium |
+| 29 | `GetVersion` | v4 + Live | low |
+| 30 | `PingAPI` | v4 + Live | low |
+| 31 | `PingAPI_X` | v4 + Live | low |
+| 32 | `UpdateBannersTags` | Live only | medium |
+| 33 | `UpdateCampaignsTags` | Live only | medium |

--- a/docs/v4_methods_matrix.md
+++ b/docs/v4_methods_matrix.md
@@ -1,0 +1,143 @@
+# Yandex Direct API v4 / v4 Live — Methods Matrix
+**Date:** 2026-04-27
+
+Source of truth: live WSDL endpoints
+- v4: `https://api.direct.yandex.ru/v4/wsdl/`
+- v4 Live: `https://api.direct.yandex.ru/live/v4/wsdl/`
+
+Status semantics:
+- **deprecated_with_v5_replacement** — direct v5 analogue exists; new code should use v5.
+- **actual_no_v5_analogue** — no v5 equivalent; candidate for implementation in this library.
+- **unclassified** — not yet classified in `V4_TO_V5_MAP`; needs review.
+
+## Summary
+
+| Category | Count |
+|---|---|
+| Total v4 / v4 Live operations (from WSDL) | 74 |
+| Operations also available in v4 Live only | 17 |
+| Operations available in both v4 and Live | 57 |
+| Operations available only in v4 (not Live) | 0 |
+| Status: deprecated_with_v5_replacement | 42 |
+| Status: actual_no_v5_analogue (candidates) | 32 |
+| Status: unclassified (needs review) | 0 |
+| Priority: high (issue-mentioned candidates) | 20 |
+| Priority: medium (other actual candidates) | 12 |
+
+## Full method table
+
+| # | Method | Availability | Status | v5 equivalent | Priority |
+|---|---|---|---|---|---|
+| 1 | `AccountManagement` | Live only | actual_no_v5_analogue | — | high |
+| 2 | `AdImage` | Live only | deprecated_with_v5_replacement | `adimages.add` | low |
+| 3 | `AdImageAssociation` | Live only | actual_no_v5_analogue | — | medium |
+| 4 | `ArchiveBanners` | v4 + Live | deprecated_with_v5_replacement | `ads.archive` | low |
+| 5 | `ArchiveCampaign` | v4 + Live | deprecated_with_v5_replacement | `campaigns.archive` | low |
+| 6 | `CheckPayment` | v4 + Live | actual_no_v5_analogue | — | medium |
+| 7 | `CreateInvoice` | v4 + Live | actual_no_v5_analogue | — | high |
+| 8 | `CreateNewForecast` | v4 + Live | actual_no_v5_analogue | — | high |
+| 9 | `CreateNewReport` | v4 + Live | deprecated_with_v5_replacement | `reports.get` | low |
+| 10 | `CreateNewSubclient` | v4 + Live | deprecated_with_v5_replacement | `agencyclients.add` | low |
+| 11 | `CreateNewWordstatReport` | v4 + Live | actual_no_v5_analogue | — | high |
+| 12 | `CreateOfflineReport` | Live only | deprecated_with_v5_replacement | `reports.get` | low |
+| 13 | `CreateOrUpdateBanners` | v4 + Live | deprecated_with_v5_replacement | `ads.add` | low |
+| 14 | `CreateOrUpdateCampaign` | v4 + Live | deprecated_with_v5_replacement | `campaigns.add` | low |
+| 15 | `DeleteBanners` | v4 + Live | deprecated_with_v5_replacement | `ads.delete` | low |
+| 16 | `DeleteCampaign` | v4 + Live | deprecated_with_v5_replacement | `campaigns.delete` | low |
+| 17 | `DeleteForecastReport` | v4 + Live | actual_no_v5_analogue | — | high |
+| 18 | `DeleteOfflineReport` | Live only | actual_no_v5_analogue | — | medium |
+| 19 | `DeleteReport` | v4 + Live | actual_no_v5_analogue | — | medium |
+| 20 | `DeleteWordstatReport` | v4 + Live | actual_no_v5_analogue | — | high |
+| 21 | `EnableSharedAccount` | Live only | actual_no_v5_analogue | — | high |
+| 22 | `GetAvailableVersions` | v4 + Live | actual_no_v5_analogue | — | medium |
+| 23 | `GetBalance` | v4 + Live | actual_no_v5_analogue | — | high |
+| 24 | `GetBannerPhrases` | v4 + Live | deprecated_with_v5_replacement | `keywords.get` | low |
+| 25 | `GetBannerPhrasesFilter` | v4 + Live | deprecated_with_v5_replacement | `keywords.get` | low |
+| 26 | `GetBanners` | v4 + Live | deprecated_with_v5_replacement | `ads.get` | low |
+| 27 | `GetBannersStat` | Live only | deprecated_with_v5_replacement | `reports.get` | low |
+| 28 | `GetBannersTags` | Live only | actual_no_v5_analogue | — | medium |
+| 29 | `GetCampaignParams` | v4 + Live | deprecated_with_v5_replacement | `campaigns.get` | low |
+| 30 | `GetCampaignsList` | v4 + Live | deprecated_with_v5_replacement | `campaigns.get` | low |
+| 31 | `GetCampaignsListFilter` | v4 + Live | deprecated_with_v5_replacement | `campaigns.get` | low |
+| 32 | `GetCampaignsParams` | v4 + Live | deprecated_with_v5_replacement | `campaigns.get` | low |
+| 33 | `GetCampaignsTags` | Live only | actual_no_v5_analogue | — | medium |
+| 34 | `GetChanges` | v4 + Live | deprecated_with_v5_replacement | `changes.check` | low |
+| 35 | `GetClientInfo` | v4 + Live | deprecated_with_v5_replacement | `clients.get` | low |
+| 36 | `GetClientsList` | v4 + Live | deprecated_with_v5_replacement | `agencyclients.get` | low |
+| 37 | `GetClientsUnits` | v4 + Live | actual_no_v5_analogue | — | high |
+| 38 | `GetCreditLimits` | v4 + Live | actual_no_v5_analogue | — | high |
+| 39 | `GetEventsLog` | Live only | actual_no_v5_analogue | — | high |
+| 40 | `GetForecast` | v4 + Live | actual_no_v5_analogue | — | high |
+| 41 | `GetForecastList` | v4 + Live | actual_no_v5_analogue | — | high |
+| 42 | `GetKeywordsSuggestion` | v4 + Live | deprecated_with_v5_replacement | `keywordsresearch.deduplicate` | low |
+| 43 | `GetOfflineReportList` | Live only | deprecated_with_v5_replacement | `reports.get` | low |
+| 44 | `GetRegions` | v4 + Live | deprecated_with_v5_replacement | `dictionaries.get` | low |
+| 45 | `GetReportList` | v4 + Live | deprecated_with_v5_replacement | `reports.get` | low |
+| 46 | `GetRetargetingGoals` | Live only | actual_no_v5_analogue | — | high |
+| 47 | `GetRubrics` | v4 + Live | deprecated_with_v5_replacement | `dictionaries.get` | low |
+| 48 | `GetStatGoals` | v4 + Live | actual_no_v5_analogue | — | high |
+| 49 | `GetSubClients` | v4 + Live | deprecated_with_v5_replacement | `agencyclients.get` | low |
+| 50 | `GetSummaryStat` | v4 + Live | deprecated_with_v5_replacement | `reports.get` | low |
+| 51 | `GetTimeZones` | v4 + Live | deprecated_with_v5_replacement | `dictionaries.get` | low |
+| 52 | `GetVersion` | v4 + Live | actual_no_v5_analogue | — | medium |
+| 53 | `GetWordstatReport` | v4 + Live | actual_no_v5_analogue | — | high |
+| 54 | `GetWordstatReportList` | v4 + Live | actual_no_v5_analogue | — | high |
+| 55 | `Keyword` | Live only | deprecated_with_v5_replacement | `keywords.add` | low |
+| 56 | `ModerateBanners` | v4 + Live | deprecated_with_v5_replacement | `ads.moderate` | low |
+| 57 | `PayCampaigns` | v4 + Live | actual_no_v5_analogue | — | high |
+| 58 | `PayCampaignsByCard` | v4 + Live | actual_no_v5_analogue | — | high |
+| 59 | `PingAPI` | v4 + Live | actual_no_v5_analogue | — | medium |
+| 60 | `PingAPI_X` | v4 + Live | actual_no_v5_analogue | — | medium |
+| 61 | `ResumeBanners` | v4 + Live | deprecated_with_v5_replacement | `ads.resume` | low |
+| 62 | `ResumeCampaign` | v4 + Live | deprecated_with_v5_replacement | `campaigns.resume` | low |
+| 63 | `Retargeting` | Live only | deprecated_with_v5_replacement | `retargeting.get` | low |
+| 64 | `RetargetingCondition` | Live only | deprecated_with_v5_replacement | `retargeting.add` | low |
+| 65 | `SetAutoPrice` | v4 + Live | deprecated_with_v5_replacement | `keywordbids.setAuto` | low |
+| 66 | `StopBanners` | v4 + Live | deprecated_with_v5_replacement | `ads.suspend` | low |
+| 67 | `StopCampaign` | v4 + Live | deprecated_with_v5_replacement | `campaigns.suspend` | low |
+| 68 | `TransferMoney` | v4 + Live | actual_no_v5_analogue | — | high |
+| 69 | `UnArchiveBanners` | v4 + Live | deprecated_with_v5_replacement | `ads.unarchive` | low |
+| 70 | `UnArchiveCampaign` | v4 + Live | deprecated_with_v5_replacement | `campaigns.unarchive` | low |
+| 71 | `UpdateBannersTags` | Live only | actual_no_v5_analogue | — | medium |
+| 72 | `UpdateCampaignsTags` | Live only | actual_no_v5_analogue | — | medium |
+| 73 | `UpdateClientInfo` | v4 + Live | deprecated_with_v5_replacement | `clients.update` | low |
+| 74 | `UpdatePrices` | v4 + Live | deprecated_with_v5_replacement | `keywordbids.set` | low |
+
+## Implementation candidates
+
+Methods with no v5 analogue, sorted by priority (high → medium):
+
+| # | Method | Availability | Priority |
+|---|---|---|---|
+| 1 | `AccountManagement` | Live only | high |
+| 2 | `CreateInvoice` | v4 + Live | high |
+| 3 | `CreateNewForecast` | v4 + Live | high |
+| 4 | `CreateNewWordstatReport` | v4 + Live | high |
+| 5 | `DeleteForecastReport` | v4 + Live | high |
+| 6 | `DeleteWordstatReport` | v4 + Live | high |
+| 7 | `EnableSharedAccount` | Live only | high |
+| 8 | `GetBalance` | v4 + Live | high |
+| 9 | `GetClientsUnits` | v4 + Live | high |
+| 10 | `GetCreditLimits` | v4 + Live | high |
+| 11 | `GetEventsLog` | Live only | high |
+| 12 | `GetForecast` | v4 + Live | high |
+| 13 | `GetForecastList` | v4 + Live | high |
+| 14 | `GetRetargetingGoals` | Live only | high |
+| 15 | `GetStatGoals` | v4 + Live | high |
+| 16 | `GetWordstatReport` | v4 + Live | high |
+| 17 | `GetWordstatReportList` | v4 + Live | high |
+| 18 | `PayCampaigns` | v4 + Live | high |
+| 19 | `PayCampaignsByCard` | v4 + Live | high |
+| 20 | `TransferMoney` | v4 + Live | high |
+| 21 | `AdImageAssociation` | Live only | medium |
+| 22 | `CheckPayment` | v4 + Live | medium |
+| 23 | `DeleteOfflineReport` | Live only | medium |
+| 24 | `DeleteReport` | v4 + Live | medium |
+| 25 | `GetAvailableVersions` | v4 + Live | medium |
+| 26 | `GetBannersTags` | Live only | medium |
+| 27 | `GetCampaignsTags` | Live only | medium |
+| 28 | `GetVersion` | v4 + Live | medium |
+| 29 | `PingAPI` | v4 + Live | medium |
+| 30 | `PingAPI_X` | v4 + Live | medium |
+| 31 | `UpdateBannersTags` | Live only | medium |
+| 32 | `UpdateCampaignsTags` | Live only | medium |

--- a/scripts/audit_wsdl.py
+++ b/scripts/audit_wsdl.py
@@ -174,8 +174,9 @@ V4_TO_V5_MAP: dict[str, str | None] = {
     # AdImage (Live)
     "AdImage":                "adimages.add",
     "AdImageAssociation":     None,
-    # Keyword suggestions
-    "GetKeywordsSuggestion":  "keywordsresearch.deduplicate",
+    # Keyword suggestions — no real v5 equivalent (deduplicate removes
+    # duplicates, hasSearchVolume tests presence; neither suggests phrases).
+    "GetKeywordsSuggestion":  None,
     # ===== CANDIDATES FOR IMPLEMENTATION (no v5 equivalent) =====
     "GetClientsUnits":        None,  # client points balance — v4-only
     "GetBalance":             None,  # campaign balance — v4-only
@@ -213,6 +214,14 @@ V4_HIGH_PRIORITY_HINTS: frozenset[str] = frozenset({
     "GetForecast", "GetForecastList",
 })
 
+# Methods that have no v5 equivalent but are not worth implementing in a
+# Python client either: API-meta probes (PingAPI, GetVersion, ...) and
+# health checks. Surfaced as "actual_no_v5_analogue" but with priority "low"
+# so they do not pollute the implementation-candidates list.
+V4_NO_BUSINESS_VALUE: frozenset[str] = frozenset({
+    "PingAPI", "PingAPI_X", "GetVersion", "GetAvailableVersions",
+})
+
 
 def classify_v4_method(method: str) -> tuple[str, str | None]:
     """Classify a v4 / v4 Live operation against v5.
@@ -234,6 +243,8 @@ def classify_v4_method(method: str) -> tuple[str, str | None]:
 def v4_method_priority(method: str, status: str) -> str:
     """Return priority label for a v4 method."""
     if status == "actual_no_v5_analogue":
+        if method in V4_NO_BUSINESS_VALUE:
+            return "low"
         return "high" if method in V4_HIGH_PRIORITY_HINTS else "medium"
     if status == "deprecated_with_v5_replacement":
         return "low"
@@ -777,7 +788,11 @@ def build_report(
 ) -> str:
     today = date.today().isoformat()
     legacy_methods = legacy_methods or []
-    versions = sorted({service.version for service in discovered_services}, key=lambda v: (v != "v5", v))
+    _version_order = {"v5": 0, "v501": 1, "v4": 2, "v4live": 3}
+    versions = sorted(
+        {service.version for service in discovered_services},
+        key=lambda v: (_version_order.get(v, 99), v),
+    )
 
     n_total_lib = len(RESOURCE_CATALOG)
     n_wsdl_lib = sum(1 for i in RESOURCE_CATALOG.values() if i["type"] == "wsdl")

--- a/scripts/audit_wsdl.py
+++ b/scripts/audit_wsdl.py
@@ -31,6 +31,10 @@ import requests
 DOCS_BASE_URL = "https://yandex.com/dev/direct/doc/en/"
 V4_DOCS_BASE_URL = "https://yandex.com/dev/direct/doc/dg-v4/en/"
 
+V4_WSDL_URL = "https://api.direct.yandex.ru/v4/wsdl/"
+V4_LIVE_WSDL_URL = "https://api.direct.yandex.ru/live/v4/wsdl/"
+V4_DOCS_BASE = "https://yandex.com/dev/direct/doc/dg-v4/en"
+
 WSDL_NS = "http://schemas.xmlsoap.org/wsdl/"
 SERVICE_LINK_RE = re.compile(r"/dev/direct/doc/en/([^/#?]+)/\1(?:[#?].*)?$")
 V4_METHOD_LINK_RE = re.compile(r"/dev/direct/doc/dg-v4/en/(?:reference|live)/([^/#?]+)")
@@ -77,9 +81,22 @@ RESOURCE_CATALOG: dict[str, dict] = {
     # Non-WSDL resources
     "reports":                 {"endpoint": "reports",                "type": "reports", "methods": {"get"}},
     "debugtoken":              {"endpoint": "debugtoken",             "type": "oauth",   "methods": set()},
+    # Legacy v4 / v4 Live — single monolithic WSDL each. Library does not implement v4 yet,
+    # so lib_methods = empty set. methods = filled at runtime from real WSDL operations.
+    "v4":     {"endpoint": "v4_monolithic",      "type": "wsdl_v4",     "methods": set(), "lib_methods": set()},
+    "v4live": {"endpoint": "v4_live_monolithic", "type": "wsdl_v4live", "methods": set(), "lib_methods": set()},
 }
 
+_WSDL_TYPES = frozenset({"wsdl", "wsdl_v4", "wsdl_v4live"})
+
 WSDL_RESOURCES = {
+    name: info for name, info in RESOURCE_CATALOG.items()
+    if info["type"] in _WSDL_TYPES
+}
+
+# Subset for v5/v501 fallback discovery — excludes v4 placeholders that have
+# their own monolithic WSDL discovery path (discover_v4_wsdl_services).
+V5_WSDL_RESOURCES = {
     name: info for name, info in RESOURCE_CATALOG.items()
     if info["type"] == "wsdl"
 }
@@ -89,6 +106,138 @@ WSDL_RESOURCES = {
 KNOWN_NON_WSDL_METHODS: dict[str, set[str]] = {
     "dictionaries": {"getGeoRegions"},
 }
+
+# v4 / v4 Live operation -> v5 equivalent (None means no analogue in v5).
+# A key being present at all means the method has been classified.
+# Methods absent from this map are reported as "unclassified" by classify_v4_method.
+V4_TO_V5_MAP: dict[str, str | None] = {
+    # Campaigns
+    "GetCampaignsList":       "campaigns.get",
+    "GetCampaignsListFilter": "campaigns.get",
+    "GetCampaignsParams":     "campaigns.get",
+    "GetCampaignParams":      "campaigns.get",
+    "CreateOrUpdateCampaign": "campaigns.add",
+    "ArchiveCampaign":        "campaigns.archive",
+    "UnArchiveCampaign":      "campaigns.unarchive",
+    "DeleteCampaign":         "campaigns.delete",
+    "ResumeCampaign":         "campaigns.resume",
+    "StopCampaign":           "campaigns.suspend",
+    # Banners (= ads in v5)
+    "GetBanners":             "ads.get",
+    "CreateOrUpdateBanners":  "ads.add",
+    "ArchiveBanners":         "ads.archive",
+    "UnArchiveBanners":       "ads.unarchive",
+    "DeleteBanners":          "ads.delete",
+    "ModerateBanners":        "ads.moderate",
+    "ResumeBanners":          "ads.resume",
+    "StopBanners":            "ads.suspend",
+    "GetBannerPhrases":       "keywords.get",
+    "GetBannerPhrasesFilter": "keywords.get",
+    "Keyword":                "keywords.add",
+    # Bids
+    "SetAutoPrice":           "keywordbids.setAuto",
+    "UpdatePrices":           "keywordbids.set",
+    # Retargeting
+    "Retargeting":            "retargeting.get",
+    "RetargetingCondition":   "retargeting.add",
+    # Clients
+    "GetClientInfo":          "clients.get",
+    "UpdateClientInfo":       "clients.update",
+    "GetClientsList":         "agencyclients.get",
+    "GetSubClients":          "agencyclients.get",
+    "CreateNewSubclient":     "agencyclients.add",
+    # Dictionaries
+    "GetRegions":             "dictionaries.get",
+    "GetRubrics":             "dictionaries.get",
+    "GetTimeZones":           "dictionaries.get",
+    # Changes
+    "GetChanges":             "changes.check",
+    # Reports / stats
+    "CreateNewReport":        "reports.get",
+    "GetReportList":          "reports.get",
+    "DeleteReport":           None,
+    "GetSummaryStat":         "reports.get",
+    "GetBannersStat":         "reports.get",
+    "CreateOfflineReport":    "reports.get",
+    "DeleteOfflineReport":    None,
+    "GetOfflineReportList":   "reports.get",
+    # API meta
+    "GetAvailableVersions":   None,
+    "GetVersion":             None,
+    "PingAPI":                None,
+    "PingAPI_X":              None,
+    # Tags (Live) — no v5 equivalent
+    "GetBannersTags":         None,
+    "UpdateBannersTags":      None,
+    "GetCampaignsTags":       None,
+    "UpdateCampaignsTags":    None,
+    # AdImage (Live)
+    "AdImage":                "adimages.add",
+    "AdImageAssociation":     None,
+    # Keyword suggestions
+    "GetKeywordsSuggestion":  "keywordsresearch.deduplicate",
+    # ===== CANDIDATES FOR IMPLEMENTATION (no v5 equivalent) =====
+    "GetClientsUnits":        None,  # client points balance — v4-only
+    "GetBalance":             None,  # campaign balance — v4-only
+    "GetCreditLimits":        None,
+    "TransferMoney":          None,
+    "PayCampaigns":           None,
+    "PayCampaignsByCard":     None,
+    "CheckPayment":           None,
+    "CreateInvoice":          None,
+    "AccountManagement":      None,  # shared account (Live)
+    "EnableSharedAccount":    None,  # (Live)
+    "GetEventsLog":           None,  # (Live)
+    "GetStatGoals":           None,  # Metrika goals
+    "GetRetargetingGoals":    None,  # (Live)
+    "CreateNewWordstatReport":None,
+    "DeleteWordstatReport":   None,
+    "GetWordstatReport":      None,
+    "GetWordstatReportList":  None,
+    "CreateNewForecast":      None,
+    "DeleteForecastReport":   None,
+    "GetForecast":            None,
+    "GetForecastList":        None,
+}
+
+# Methods explicitly mentioned by the issue author as relevant / actual.
+# Used to bump priority of unmapped methods to "high".
+V4_HIGH_PRIORITY_HINTS: frozenset[str] = frozenset({
+    "GetBalance", "GetClientsUnits", "GetCreditLimits",
+    "TransferMoney", "PayCampaigns", "PayCampaignsByCard",
+    "CreateInvoice", "AccountManagement", "EnableSharedAccount",
+    "GetEventsLog", "GetStatGoals", "GetRetargetingGoals",
+    "CreateNewWordstatReport", "DeleteWordstatReport",
+    "GetWordstatReport", "GetWordstatReportList",
+    "CreateNewForecast", "DeleteForecastReport",
+    "GetForecast", "GetForecastList",
+})
+
+
+def classify_v4_method(method: str) -> tuple[str, str | None]:
+    """Classify a v4 / v4 Live operation against v5.
+
+    Returns a (status, v5_equivalent) tuple. Status is one of:
+      - "deprecated_with_v5_replacement" — method has a direct v5 analogue.
+      - "actual_no_v5_analogue" — method is in V4_TO_V5_MAP with value None
+        (= explicitly classified as "no v5 equivalent, candidate to implement").
+      - "unclassified" — method is missing from V4_TO_V5_MAP entirely.
+    """
+    if method not in V4_TO_V5_MAP:
+        return ("unclassified", None)
+    v5_eq = V4_TO_V5_MAP[method]
+    if v5_eq is None:
+        return ("actual_no_v5_analogue", None)
+    return ("deprecated_with_v5_replacement", v5_eq)
+
+
+def v4_method_priority(method: str, status: str) -> str:
+    """Return priority label for a v4 method."""
+    if status == "actual_no_v5_analogue":
+        return "high" if method in V4_HIGH_PRIORITY_HINTS else "medium"
+    if status == "deprecated_with_v5_replacement":
+        return "low"
+    return "?"
 
 
 class DiscoveredService(NamedTuple):
@@ -452,6 +601,37 @@ def fetch_wsdl_operations(wsdl_url: str, timeout: int = 15) -> tuple[set[str], b
     return operations, True
 
 
+def discover_v4_wsdl_services(timeout: int) -> list[DiscoveredService]:
+    """Fetch the two monolithic v4 / v4 Live WSDLs and return DiscoveredService records.
+
+    Reuses fetch_wsdl_operations — same code path as v5, just with hard-coded
+    endpoints because v4 has no per-service WSDL split.
+    """
+    targets = [
+        ("v4",     V4_WSDL_URL,      "v4_monolithic",      f"{V4_DOCS_BASE}/concepts"),
+        ("v4live", V4_LIVE_WSDL_URL, "v4_live_monolithic", f"{V4_DOCS_BASE}/live/concepts"),
+    ]
+    services: list[DiscoveredService] = []
+    for version, wsdl_url, endpoint, docs_url in targets:
+        ops, available = fetch_wsdl_operations(wsdl_url, timeout)
+        if not available:
+            print(f"  Warning: WSDL {wsdl_url} unavailable", file=sys.stderr)
+            continue
+        soap_url = wsdl_url.replace("/wsdl/", "/")
+        services.append(DiscoveredService(
+            version=version,
+            name=version,
+            endpoint=endpoint,
+            docs_url=docs_url,
+            methods=ops,
+            wsdl_url=wsdl_url,
+            soap_url=soap_url,
+            json_url=None,
+        ))
+        print(f"  [{version}] {len(ops)} operations from {wsdl_url}", file=sys.stderr)
+    return services
+
+
 def _library_entry(endpoint: str) -> tuple[str, dict] | None:
     return next(
         ((name, info) for name, info in WSDL_RESOURCES.items() if info["endpoint"] == endpoint),
@@ -469,7 +649,14 @@ def _coverage_rows(
         for service in discovered_services
         if service.version == version
     }
-    library_endpoints = {info["endpoint"] for info in WSDL_RESOURCES.values()}
+    if version in {"v4", "v4live"}:
+        type_key = "wsdl_v4" if version == "v4" else "wsdl_v4live"
+        library_endpoints = {
+            info["endpoint"] for info in RESOURCE_CATALOG.values()
+            if info["type"] == type_key
+        }
+    else:
+        library_endpoints = {info["endpoint"] for info in V5_WSDL_RESOURCES.values()}
     all_endpoints = sorted(set(services_by_endpoint) | library_endpoints)
 
     rows: list[dict] = []
@@ -479,7 +666,7 @@ def _coverage_rows(
 
         if lib_entry:
             lib_name, lib_info = lib_entry
-            lib_methods = lib_info["methods"]
+            lib_methods = lib_info.get("lib_methods", lib_info["methods"])
         else:
             lib_name = None
             lib_methods = set()
@@ -593,9 +780,10 @@ def build_report(
     versions = sorted({service.version for service in discovered_services}, key=lambda v: (v != "v5", v))
 
     n_total_lib = len(RESOURCE_CATALOG)
-    n_wsdl_lib = len(WSDL_RESOURCES)
+    n_wsdl_lib = sum(1 for i in RESOURCE_CATALOG.values() if i["type"] == "wsdl")
     n_reports = sum(1 for i in RESOURCE_CATALOG.values() if i["type"] == "reports")
     n_oauth = sum(1 for i in RESOURCE_CATALOG.values() if i["type"] == "oauth")
+    n_v4 = sum(1 for i in RESOURCE_CATALOG.values() if i["type"] in {"wsdl_v4", "wsdl_v4live"})
 
     lines = [
         "# Yandex Direct API - Official Docs WSDL/SOAP Audit Report",
@@ -606,9 +794,10 @@ def build_report(
         "| Category | Count |",
         "|---|---|",
         f"| Total resources in `resource_mapping.py` | {n_total_lib} |",
-        f"| — SOAP/WSDL services | {n_wsdl_lib} |",
+        f"| — SOAP/WSDL services (v5) | {n_wsdl_lib} |",
         f"| — Reports API (non-SOAP) | {n_reports} |",
         f"| — OAuth helpers | {n_oauth} |",
+        f"| — Legacy v4 / v4 Live placeholders | {n_v4} |",
         f"| Official docs versions | {', '.join(versions) if versions else 'none'} |",
         f"| Official docs WSDL entries | {len(discovered_services)} |",
         f"| Legacy v4 methods | {len(legacy_methods)} |",
@@ -622,7 +811,7 @@ def build_report(
         "",
     ]
     for i, (name, info) in enumerate(
-        ((n, i) for n, i in RESOURCE_CATALOG.items() if i["type"] != "wsdl"), start=1
+        ((n, i) for n, i in RESOURCE_CATALOG.items() if i["type"] not in _WSDL_TYPES), start=1
     ):
         type_label = {"reports": "Reports API (TSV, async)", "oauth": "OAuth helper"}.get(info["type"], info["type"])
         lines.append(f"{i}. **{name}** (`{info['endpoint']}`) — {type_label}")
@@ -642,6 +831,120 @@ def build_report(
             lines.append(f"{i}. **{method.name}** — {method.docs_url}")
         lines.append("")
 
+    return "\n".join(lines)
+
+
+def build_v4_matrix(v4_services: list[DiscoveredService]) -> str:
+    """Render a stand-alone Markdown matrix of v4 / v4 Live operations vs v5.
+
+    Uses real WSDL operations (not docs) as the source of truth. Each operation
+    is classified via classify_v4_method against V4_TO_V5_MAP.
+    """
+    today = date.today().isoformat()
+    by_version: dict[str, set[str]] = {svc.version: set(svc.methods) for svc in v4_services}
+    v4_ops = by_version.get("v4", set())
+    live_ops = by_version.get("v4live", set())
+    all_ops = v4_ops | live_ops
+
+    rows: list[dict] = []
+    for op in sorted(all_ops):
+        status, v5_eq = classify_v4_method(op)
+        priority = v4_method_priority(op, status)
+        in_v4 = op in v4_ops
+        in_live = op in live_ops
+        if in_v4 and in_live:
+            availability = "v4 + Live"
+        elif in_live:
+            availability = "Live only"
+        else:
+            availability = "v4 only"
+        rows.append({
+            "method": op,
+            "availability": availability,
+            "status": status,
+            "v5_equivalent": v5_eq,
+            "priority": priority,
+        })
+
+    n_total = len(rows)
+    n_actual = sum(1 for r in rows if r["status"] == "actual_no_v5_analogue")
+    n_dep = sum(1 for r in rows if r["status"] == "deprecated_with_v5_replacement")
+    n_unclassified = sum(1 for r in rows if r["status"] == "unclassified")
+    n_high = sum(1 for r in rows if r["priority"] == "high")
+    n_medium = sum(1 for r in rows if r["priority"] == "medium")
+
+    lines: list[str] = [
+        "# Yandex Direct API v4 / v4 Live — Methods Matrix",
+        f"**Date:** {today}",
+        "",
+        "Source of truth: live WSDL endpoints",
+        f"- v4: `{V4_WSDL_URL}`",
+        f"- v4 Live: `{V4_LIVE_WSDL_URL}`",
+        "",
+        "Status semantics:",
+        "- **deprecated_with_v5_replacement** — direct v5 analogue exists; new code should use v5.",
+        "- **actual_no_v5_analogue** — no v5 equivalent; candidate for implementation in this library.",
+        "- **unclassified** — not yet classified in `V4_TO_V5_MAP`; needs review.",
+        "",
+        "## Summary",
+        "",
+        "| Category | Count |",
+        "|---|---|",
+        f"| Total v4 / v4 Live operations (from WSDL) | {n_total} |",
+        f"| Operations also available in v4 Live only | {sum(1 for r in rows if r['availability'] == 'Live only')} |",
+        f"| Operations available in both v4 and Live | {sum(1 for r in rows if r['availability'] == 'v4 + Live')} |",
+        f"| Operations available only in v4 (not Live) | {sum(1 for r in rows if r['availability'] == 'v4 only')} |",
+        f"| Status: deprecated_with_v5_replacement | {n_dep} |",
+        f"| Status: actual_no_v5_analogue (candidates) | {n_actual} |",
+        f"| Status: unclassified (needs review) | {n_unclassified} |",
+        f"| Priority: high (issue-mentioned candidates) | {n_high} |",
+        f"| Priority: medium (other actual candidates) | {n_medium} |",
+        "",
+        "## Full method table",
+        "",
+        "| # | Method | Availability | Status | v5 equivalent | Priority |",
+        "|---|---|---|---|---|---|",
+    ]
+    for i, row in enumerate(rows, start=1):
+        v5_cell = f"`{row['v5_equivalent']}`" if row["v5_equivalent"] else "—"
+        lines.append(
+            f"| {i} | `{row['method']}` | {row['availability']} | {row['status']} | "
+            f"{v5_cell} | {row['priority']} |"
+        )
+
+    lines += [
+        "",
+        "## Implementation candidates",
+        "",
+        "Methods with no v5 analogue, sorted by priority (high → medium):",
+        "",
+    ]
+    candidates = [r for r in rows if r["status"] == "actual_no_v5_analogue"]
+    candidates.sort(key=lambda r: (0 if r["priority"] == "high" else 1, r["method"]))
+    if candidates:
+        lines.append("| # | Method | Availability | Priority |")
+        lines.append("|---|---|---|---|")
+        for i, row in enumerate(candidates, start=1):
+            lines.append(
+                f"| {i} | `{row['method']}` | {row['availability']} | {row['priority']} |"
+            )
+    else:
+        lines.append("_No candidates — every method is either deprecated or unclassified._")
+
+    if n_unclassified > 0:
+        lines += [
+            "",
+            "## Unclassified operations",
+            "",
+            "These operations were found in the live WSDL but are missing from `V4_TO_V5_MAP`. "
+            "Add them to the map before treating this matrix as final.",
+            "",
+        ]
+        for row in rows:
+            if row["status"] == "unclassified":
+                lines.append(f"- `{row['method']}` ({row['availability']})")
+
+    lines.append("")
     return "\n".join(lines)
 
 
@@ -692,6 +995,10 @@ def main() -> None:
                         help="HTTP timeout in seconds")
     parser.add_argument("--max-pages", type=int, default=200,
                         help="Maximum pages to crawl in BFS discovery (default: 200)")
+    parser.add_argument("--v4-matrix", metavar="FILE",
+                        help="Generate the v4 / v4 Live methods matrix to a separate Markdown file")
+    parser.add_argument("--legacy-v4-docs", action="store_true",
+                        help="Also crawl legacy v4 docs pages (slow, often captcha-blocked)")
     args = parser.parse_args()
 
     requested_versions = {version.strip() for version in args.versions.split(",") if version.strip()}
@@ -709,13 +1016,22 @@ def main() -> None:
             if service.version in requested_versions
         ]
 
+    v4_services: list[DiscoveredService] = []
     if "v4" in requested_versions:
-        legacy_methods = discover_v4_methods_from_docs(args.v4_docs_base_url, args.timeout)
+        v4_services = discover_v4_wsdl_services(args.timeout)
+        discovered_services.extend(v4_services)
+        if args.legacy_v4_docs:
+            legacy_methods = discover_v4_methods_from_docs(args.v4_docs_base_url, args.timeout)
 
     wsdl_results: dict[str, tuple[set[str], bool]] = {}
     seen_wsdl: set[str] = set()
-    print(f"\nFetching WSDL for {len(discovered_services)} official docs entries...", file=sys.stderr)
-    for service in discovered_services:
+    # v4 services were already fetched inside discover_v4_wsdl_services — reuse their methods.
+    for service in v4_services:
+        wsdl_results[service.wsdl_url] = (service.methods, True)
+        seen_wsdl.add(service.wsdl_url)
+    v5_like = [s for s in discovered_services if s.version not in {"v4", "v4live"}]
+    print(f"\nFetching WSDL for {len(v5_like)} official docs entries...", file=sys.stderr)
+    for service in v5_like:
         if service.wsdl_url not in seen_wsdl:
             seen_wsdl.add(service.wsdl_url)
             ops, available = fetch_wsdl_operations(service.wsdl_url, args.timeout)
@@ -729,7 +1045,7 @@ def main() -> None:
     # Fallback: fetch WSDL for library resources not found in official docs
     discovered_endpoints = {s.endpoint for s in discovered_services}
     for version in requested_versions & {"v5", "v501"}:
-        for name, info in WSDL_RESOURCES.items():
+        for name, info in V5_WSDL_RESOURCES.items():
             endpoint = info["endpoint"]
             if endpoint not in discovered_endpoints:
                 wsdl_url = f"https://api.direct.yandex.com/{version}/{endpoint}?wsdl"
@@ -762,6 +1078,21 @@ def main() -> None:
         print(f"Report saved to {args.output}", file=sys.stderr)
     else:
         print(report)
+
+    if args.v4_matrix:
+        if not v4_services:
+            print(
+                "Warning: --v4-matrix requested but v4 WSDL discovery returned nothing. "
+                "Ensure 'v4' is in --versions and the WSDL endpoints are reachable.",
+                file=sys.stderr,
+            )
+        matrix = build_v4_matrix(v4_services)
+        out_dir = os.path.dirname(args.v4_matrix)
+        if out_dir:
+            os.makedirs(out_dir, exist_ok=True)
+        with open(args.v4_matrix, "w", encoding="utf-8") as f:
+            f.write(matrix)
+        print(f"v4 matrix saved to {args.v4_matrix}", file=sys.stderr)
 
     if args.issue:
         create_github_issue(report)

--- a/tests/test_audit_wsdl.py
+++ b/tests/test_audit_wsdl.py
@@ -402,9 +402,10 @@ def test_build_v4_matrix_handles_empty_input():
 
 def test_v4_to_v5_map_covers_all_known_v4_live_operations():
     # Source of truth: real WSDL operation list captured at the time this audit
-    # was authored (74 ops). If Yandex adds new operations, classify them in
-    # V4_TO_V5_MAP — otherwise this guard fails and the matrix grows
-    # an "unclassified" section.
+    # was authored (74 ops). The set is static — Yandex-side additions are NOT
+    # detected automatically; only a manual update to known_v4_live_ops or to
+    # V4_TO_V5_MAP triggers this guard. If you grow either set and forget the
+    # other, the assertion below catches the desync.
     known_v4_live_ops = {
         "AccountManagement", "AdImage", "AdImageAssociation", "ArchiveBanners",
         "ArchiveCampaign", "CheckPayment", "CreateInvoice", "CreateNewForecast",
@@ -433,4 +434,9 @@ def test_v4_to_v5_map_covers_all_known_v4_live_operations():
     assert not missing, (
         f"V4_TO_V5_MAP must classify every known v4 / v4 Live WSDL operation. "
         f"Add entries for: {sorted(missing)}"
+    )
+    extra = set(audit_wsdl.V4_TO_V5_MAP) - known_v4_live_ops
+    assert not extra, (
+        f"V4_TO_V5_MAP contains entries not in known_v4_live_ops "
+        f"(possible typos in keys): {sorted(extra)}"
     )

--- a/tests/test_audit_wsdl.py
+++ b/tests/test_audit_wsdl.py
@@ -299,13 +299,16 @@ def test_v4_method_priority_high_for_issue_mentioned_actual():
     assert audit_wsdl.v4_method_priority(
         "GetBalance", "actual_no_v5_analogue"
     ) == "high"
-    # An actual method NOT in the issue hints should be medium.
-    # PingAPI is mapped to None (actual) but irrelevant for issue → medium.
-    # Use a method in V4_TO_V5_MAP=None and not in V4_HIGH_PRIORITY_HINTS:
-    # AdImageAssociation maps to None and is not in hints.
+    # An actual method NOT in the issue hints AND not in V4_NO_BUSINESS_VALUE
+    # should be medium. AdImageAssociation maps to None, is not in hints, and
+    # is not in V4_NO_BUSINESS_VALUE — so it lands in "medium".
+    # (PingAPI also maps to None but is in V4_NO_BUSINESS_VALUE → "low".)
     assert audit_wsdl.v4_method_priority(
         "AdImageAssociation", "actual_no_v5_analogue"
     ) == "medium"
+    assert audit_wsdl.v4_method_priority(
+        "PingAPI", "actual_no_v5_analogue"
+    ) == "low"
     assert audit_wsdl.v4_method_priority(
         "GetCampaignsList", "deprecated_with_v5_replacement"
     ) == "low"

--- a/tests/test_audit_wsdl.py
+++ b/tests/test_audit_wsdl.py
@@ -275,3 +275,162 @@ def test_build_report_separates_v5_v501_and_v4_coverage():
     assert "Missing in library (1):** `archive`" in report
     assert "newMethod" in report
     assert "CreateNewWordstatReport" in report
+
+
+def test_classify_v4_method_returns_v5_equivalent_for_mapped_method():
+    status, v5_eq = audit_wsdl.classify_v4_method("GetCampaignsList")
+    assert status == "deprecated_with_v5_replacement"
+    assert v5_eq == "campaigns.get"
+
+
+def test_classify_v4_method_returns_none_for_actual_candidate():
+    status, v5_eq = audit_wsdl.classify_v4_method("GetClientsUnits")
+    assert status == "actual_no_v5_analogue"
+    assert v5_eq is None
+
+
+def test_classify_v4_method_returns_unclassified_for_unknown():
+    status, v5_eq = audit_wsdl.classify_v4_method("SomeBrandNewOperation")
+    assert status == "unclassified"
+    assert v5_eq is None
+
+
+def test_v4_method_priority_high_for_issue_mentioned_actual():
+    assert audit_wsdl.v4_method_priority(
+        "GetBalance", "actual_no_v5_analogue"
+    ) == "high"
+    # An actual method NOT in the issue hints should be medium.
+    # PingAPI is mapped to None (actual) but irrelevant for issue → medium.
+    # Use a method in V4_TO_V5_MAP=None and not in V4_HIGH_PRIORITY_HINTS:
+    # AdImageAssociation maps to None and is not in hints.
+    assert audit_wsdl.v4_method_priority(
+        "AdImageAssociation", "actual_no_v5_analogue"
+    ) == "medium"
+    assert audit_wsdl.v4_method_priority(
+        "GetCampaignsList", "deprecated_with_v5_replacement"
+    ) == "low"
+    assert audit_wsdl.v4_method_priority("Whatever", "unclassified") == "?"
+
+
+def test_discover_v4_wsdl_services_uses_monolithic_endpoints(monkeypatch):
+    fetched: list[str] = []
+
+    def fake_fetch(url, timeout):
+        fetched.append(url)
+        if "live" in url:
+            return ({"GetEventsLog", "AccountManagement", "GetBalance"}, True)
+        return ({"GetBalance", "GetCampaignsList"}, True)
+
+    monkeypatch.setattr(audit_wsdl, "fetch_wsdl_operations", fake_fetch)
+
+    services = audit_wsdl.discover_v4_wsdl_services(timeout=5)
+
+    assert fetched == [audit_wsdl.V4_WSDL_URL, audit_wsdl.V4_LIVE_WSDL_URL]
+    assert [s.version for s in services] == ["v4", "v4live"]
+    assert services[0].wsdl_url == audit_wsdl.V4_WSDL_URL
+    assert services[1].wsdl_url == audit_wsdl.V4_LIVE_WSDL_URL
+    assert services[0].methods == {"GetBalance", "GetCampaignsList"}
+    assert services[1].methods == {"GetEventsLog", "AccountManagement", "GetBalance"}
+
+
+def test_discover_v4_wsdl_services_skips_unavailable(monkeypatch, capsys):
+    def fake_fetch(url, timeout):
+        if "live" in url:
+            return (set(), False)
+        return ({"GetBalance"}, True)
+
+    monkeypatch.setattr(audit_wsdl, "fetch_wsdl_operations", fake_fetch)
+
+    services = audit_wsdl.discover_v4_wsdl_services(timeout=5)
+
+    assert [s.version for s in services] == ["v4"]
+    err = capsys.readouterr().err
+    assert "unavailable" in err
+
+
+def test_build_v4_matrix_includes_priority_and_v5_equivalent():
+    DiscoveredService = audit_wsdl.DiscoveredService
+    v4_svc = DiscoveredService(
+        version="v4",
+        name="v4",
+        endpoint="v4_monolithic",
+        docs_url="",
+        methods={"GetCampaignsList", "GetBalance"},
+        wsdl_url=audit_wsdl.V4_WSDL_URL,
+        soap_url="https://api.direct.yandex.ru/v4/",
+        json_url=None,
+    )
+    live_svc = DiscoveredService(
+        version="v4live",
+        name="v4live",
+        endpoint="v4_live_monolithic",
+        docs_url="",
+        methods={"GetCampaignsList", "GetBalance", "AccountManagement", "BogusUnclassifiedOp"},
+        wsdl_url=audit_wsdl.V4_LIVE_WSDL_URL,
+        soap_url="https://api.direct.yandex.ru/live/v4/",
+        json_url=None,
+    )
+
+    matrix = audit_wsdl.build_v4_matrix([v4_svc, live_svc])
+
+    assert "# Yandex Direct API v4 / v4 Live — Methods Matrix" in matrix
+    # Deprecated v5 mapping rendered in table
+    assert "`GetCampaignsList`" in matrix
+    assert "`campaigns.get`" in matrix
+    assert "deprecated_with_v5_replacement" in matrix
+    assert "low" in matrix
+    # Actual + high priority (issue-mentioned)
+    assert "`GetBalance`" in matrix
+    assert "actual_no_v5_analogue" in matrix
+    assert "high" in matrix
+    assert "`AccountManagement`" in matrix
+    # Availability column
+    assert "v4 + Live" in matrix
+    assert "Live only" in matrix
+    # Unclassified surfaces in dedicated section
+    assert "Unclassified operations" in matrix
+    assert "`BogusUnclassifiedOp`" in matrix
+    # Implementation candidates list
+    assert "Implementation candidates" in matrix
+
+
+def test_build_v4_matrix_handles_empty_input():
+    matrix = audit_wsdl.build_v4_matrix([])
+    assert "Total v4 / v4 Live operations (from WSDL) | 0" in matrix
+    assert "No candidates" in matrix
+
+
+def test_v4_to_v5_map_covers_all_known_v4_live_operations():
+    # Source of truth: real WSDL operation list captured at the time this audit
+    # was authored (74 ops). If Yandex adds new operations, classify them in
+    # V4_TO_V5_MAP — otherwise this guard fails and the matrix grows
+    # an "unclassified" section.
+    known_v4_live_ops = {
+        "AccountManagement", "AdImage", "AdImageAssociation", "ArchiveBanners",
+        "ArchiveCampaign", "CheckPayment", "CreateInvoice", "CreateNewForecast",
+        "CreateNewReport", "CreateNewSubclient", "CreateNewWordstatReport",
+        "CreateOfflineReport", "CreateOrUpdateBanners", "CreateOrUpdateCampaign",
+        "DeleteBanners", "DeleteCampaign", "DeleteForecastReport",
+        "DeleteOfflineReport", "DeleteReport", "DeleteWordstatReport",
+        "EnableSharedAccount", "GetAvailableVersions", "GetBalance",
+        "GetBannerPhrases", "GetBannerPhrasesFilter", "GetBanners",
+        "GetBannersStat", "GetBannersTags", "GetCampaignParams",
+        "GetCampaignsList", "GetCampaignsListFilter", "GetCampaignsParams",
+        "GetCampaignsTags", "GetChanges", "GetClientInfo", "GetClientsList",
+        "GetClientsUnits", "GetCreditLimits", "GetEventsLog", "GetForecast",
+        "GetForecastList", "GetKeywordsSuggestion", "GetOfflineReportList",
+        "GetRegions", "GetReportList", "GetRetargetingGoals", "GetRubrics",
+        "GetStatGoals", "GetSubClients", "GetSummaryStat", "GetTimeZones",
+        "GetVersion", "GetWordstatReport", "GetWordstatReportList", "Keyword",
+        "ModerateBanners", "PayCampaigns", "PayCampaignsByCard", "PingAPI",
+        "PingAPI_X", "ResumeBanners", "ResumeCampaign", "Retargeting",
+        "RetargetingCondition", "SetAutoPrice", "StopBanners", "StopCampaign",
+        "TransferMoney", "UnArchiveBanners", "UnArchiveCampaign",
+        "UpdateBannersTags", "UpdateCampaignsTags", "UpdateClientInfo",
+        "UpdatePrices",
+    }
+    missing = known_v4_live_ops - set(audit_wsdl.V4_TO_V5_MAP)
+    assert not missing, (
+        f"V4_TO_V5_MAP must classify every known v4 / v4 Live WSDL operation. "
+        f"Add entries for: {sorted(missing)}"
+    )


### PR DESCRIPTION
Phase 1 of #15 — inventory of v4 / v4 Live operations before any client work, per the issue requirement: «сначала создать WSDL покрытие. Начинать делать только после определения списка сервисов, списка функций, какие устарели/какие не устарели».

## Approach

Reuses the existing v5 audit infrastructure (`fetch_wsdl_operations`, `_coverage_rows`, `build_report`) by treating v4 and v4 Live as **monolithic pseudo-services** pinned to the real Yandex endpoints:

- `https://api.direct.yandex.ru/v4/wsdl/` — 57 operations
- `https://api.direct.yandex.ru/live/v4/wsdl/` — 74 operations (v4 + 17 Live-only)

Per-service WSDL URLs in the style `…/v4/Campaigns?wsdl` **do not exist** (404) — verified by direct probing. Live docs pages are JS-rendered and frequently captcha-blocked, so the older docs-page crawler is now gated behind `--legacy-v4-docs` (off by default). Status classification comes from a hand-curated `V4_TO_V5_MAP`, not from parsing deprecation banners.

## What's new

- `V4_TO_V5_MAP`: every WSDL operation is mapped to a v5 equivalent or `None` (= candidate for implementation).
- `classify_v4_method` / `v4_method_priority`: status + priority derivation.
- `discover_v4_wsdl_services`: same code path as v5 discovery, hard-coded endpoints.
- `build_v4_matrix` + `--v4-matrix PATH` CLI flag: standalone Markdown matrix.
- 9 new tests in `tests/test_audit_wsdl.py` covering classify/priority/discover/matrix + a coverage guard that fails if `V4_TO_V5_MAP` ever falls behind the real WSDL.

## Generated matrix

[`docs/v4_methods_matrix.md`](https://github.com/axisrow/tapi-yandex-direct/blob/feat/v4-audit-matrix/docs/v4_methods_matrix.md):

| | Count |
|---|---|
| Total operations | 74 |
| Deprecated with v5 replacement | 42 |
| Actual / no v5 analogue (candidates) | **32** |
| — high priority (issue-mentioned) | 20 |
| — medium priority | 12 |
| Unclassified | 0 |

High-priority candidates include `GetBalance`, `GetClientsUnits`, `GetCreditLimits`, `TransferMoney`, `PayCampaigns`, `PayCampaignsByCard`, `CreateInvoice`, `AccountManagement`, `EnableSharedAccount`, `GetEventsLog`, `GetStatGoals`, `GetRetargetingGoals`, and the Wordstat / Forecast families.

## What's NOT in this PR

- No v4 / v4 Live client (no new modules in `tapi_yandex_direct/`).
- No SOAP dependencies (`zeep`, `lxml`).
- No changes to `setup.py`, `__init__.py`, `exceptions.py`, or `resource_mapping.py`.

Phase 2 (client implementation) is a separate PR, to be opened after the matrix is reviewed and the candidate list is agreed upon.

## Verification

```bash
python -m pytest tests/test_audit_wsdl.py -v        # 18 passed
python scripts/audit_wsdl.py --versions v4 --v4-matrix docs/v4_methods_matrix.md
```