### PR TITLE
fix(v4): tighten SUPPORTED_V4_METHODS and integration probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,71 @@ except V4LiveError as e:
 | `error_code` type | string | integer |
 | Pagination | `LimitedBy` in result, offset injection | per-method (`Limit`, `TimestampFrom`, …) — single-shot at the adapter level |
 
+### Methods removed from v4 Live by Yandex
+
+`GetBalance` is still in the v4 Live WSDL but Yandex disabled it server-side
+— calling it returns `V4LiveError(error_code=509, error_str="This method is
+not available in this API version")`. Use the v5 client instead:
+
+```python
+from tapi_yandex_direct import YandexDirect
+client = YandexDirect(access_token=ACCESS_TOKEN)
+campaigns = client.campaigns().post(data={
+    "method": "get",
+    "params": {
+        "SelectionCriteria": {"Ids": [<campaign_id>]},
+        "FieldNames": ["Id", "Funds"],   # Funds carries the campaign balance
+    },
+})
+```
+
+### Finance methods (financial_token required)
+
+`GetCreditLimits`, `TransferMoney`, `PayCampaigns`, `PayCampaignsByCard`,
+`CheckPayment` and `CreateInvoice` are finance operations and reject the
+regular OAuth `access_token` with `V4LiveError(error_code=350, error_str=
+"Invalid financial transaction token")`. Yandex requires a separate
+**financial token** generated from the OAuth client secret + login +
+operation number — see
+<https://yandex.com/dev/direct/doc/dg-v4/en/concepts/finance>. Pass it
+explicitly inside the `param` block of the request:
+
+```python
+client.v4live().post(data={
+    "method": "TransferMoney",
+    "param": {
+        "Login": "<login>",
+        "OperationNum": <int>,
+        "FinanceToken": "<finance-token>",
+        # ... other method-specific fields ...
+    },
+})
+```
+
+The library does **not** generate finance tokens for you — that flow involves
+the OAuth client secret and is out of scope. See the issue body of #18 for
+the verified live-API behaviour of every supported method.
+
+### Common request schemas
+
+The full call schemas come from
+<https://yandex.com/dev/direct/doc/dg-v4/en/live/concepts>. A few that trip
+up newcomers (verified live):
+
+| Method | Required `param` shape |
+|---|---|
+| `GetClientsUnits` | list of logins, e.g. `["my-login"]` |
+| `GetRetargetingGoals` | `{"Login": "my-login"}` |
+| `GetStatGoals` | `{"CampaignIDS": [<int>, ...]}` (capital S) |
+| `GetCampaignsTags` | `{"CampaignIDS": [<int>, ...]}` |
+| `GetBannersTags` | `{"BannerIDS": [<int>, ...]}` |
+| `GetEventsLog` | `{"TimestampFrom": "<ISO 8601>", "Currency": "RUB"\|"USD"\|...}` |
+| `GetKeywordsSuggestion` | `{"Keywords": ["phrase 1", ...]}` |
+
+`tests/test_v4_live_integration.py` exercises each of these against the real
+API as living documentation — run with `pytest -m live` and a token in
+`YANDEX_DIRECT_TOKEN`.
+
 
 ## Features
 

--- a/docs/v4_methods_matrix.md
+++ b/docs/v4_methods_matrix.md
@@ -8,6 +8,7 @@ Source of truth: live WSDL endpoints
 Status semantics:
 - **deprecated_with_v5_replacement** — direct v5 analogue exists; new code should use v5.
 - **actual_no_v5_analogue** — no v5 equivalent; candidate for implementation in this library.
+- **removed_from_v4_live** — operation is in the WSDL but Yandex disabled it server-side (error_code 509); use the v5 client.
 - **unclassified** — not yet classified in `V4_TO_V5_MAP`; needs review.
 
 ## Summary
@@ -19,9 +20,10 @@ Status semantics:
 | Operations available in both v4 and Live | 57 |
 | Operations available only in v4 (not Live) | 0 |
 | Status: deprecated_with_v5_replacement | 41 |
-| Status: actual_no_v5_analogue (candidates) | 33 |
+| Status: actual_no_v5_analogue (candidates) | 32 |
+| Status: removed_from_v4_live | 1 |
 | Status: unclassified (needs review) | 0 |
-| Priority: high (issue-mentioned candidates) | 20 |
+| Priority: high (issue-mentioned candidates) | 19 |
 | Priority: medium (other actual candidates) | 9 |
 
 ## Full method table
@@ -50,7 +52,7 @@ Status semantics:
 | 20 | `DeleteWordstatReport` | v4 + Live | actual_no_v5_analogue | — | high |
 | 21 | `EnableSharedAccount` | Live only | actual_no_v5_analogue | — | high |
 | 22 | `GetAvailableVersions` | v4 + Live | actual_no_v5_analogue | — | low |
-| 23 | `GetBalance` | v4 + Live | actual_no_v5_analogue | — | high |
+| 23 | `GetBalance` | v4 + Live | removed_from_v4_live | — | skip |
 | 24 | `GetBannerPhrases` | v4 + Live | deprecated_with_v5_replacement | `keywords.get` | low |
 | 25 | `GetBannerPhrasesFilter` | v4 + Live | deprecated_with_v5_replacement | `keywords.get` | low |
 | 26 | `GetBanners` | v4 + Live | deprecated_with_v5_replacement | `ads.get` | low |
@@ -116,29 +118,34 @@ Methods with no v5 analogue, sorted by priority (high → medium):
 | 5 | `DeleteForecastReport` | v4 + Live | high |
 | 6 | `DeleteWordstatReport` | v4 + Live | high |
 | 7 | `EnableSharedAccount` | Live only | high |
-| 8 | `GetBalance` | v4 + Live | high |
-| 9 | `GetClientsUnits` | v4 + Live | high |
-| 10 | `GetCreditLimits` | v4 + Live | high |
-| 11 | `GetEventsLog` | Live only | high |
-| 12 | `GetForecast` | v4 + Live | high |
-| 13 | `GetForecastList` | v4 + Live | high |
-| 14 | `GetRetargetingGoals` | Live only | high |
-| 15 | `GetStatGoals` | v4 + Live | high |
-| 16 | `GetWordstatReport` | v4 + Live | high |
-| 17 | `GetWordstatReportList` | v4 + Live | high |
-| 18 | `PayCampaigns` | v4 + Live | high |
-| 19 | `PayCampaignsByCard` | v4 + Live | high |
-| 20 | `TransferMoney` | v4 + Live | high |
-| 21 | `AdImageAssociation` | Live only | medium |
-| 22 | `CheckPayment` | v4 + Live | medium |
-| 23 | `DeleteOfflineReport` | Live only | medium |
-| 24 | `DeleteReport` | v4 + Live | medium |
-| 25 | `GetAvailableVersions` | v4 + Live | low |
-| 26 | `GetBannersTags` | Live only | medium |
-| 27 | `GetCampaignsTags` | Live only | medium |
-| 28 | `GetKeywordsSuggestion` | v4 + Live | medium |
-| 29 | `GetVersion` | v4 + Live | low |
-| 30 | `PingAPI` | v4 + Live | low |
-| 31 | `PingAPI_X` | v4 + Live | low |
-| 32 | `UpdateBannersTags` | Live only | medium |
-| 33 | `UpdateCampaignsTags` | Live only | medium |
+| 8 | `GetClientsUnits` | v4 + Live | high |
+| 9 | `GetCreditLimits` | v4 + Live | high |
+| 10 | `GetEventsLog` | Live only | high |
+| 11 | `GetForecast` | v4 + Live | high |
+| 12 | `GetForecastList` | v4 + Live | high |
+| 13 | `GetRetargetingGoals` | Live only | high |
+| 14 | `GetStatGoals` | v4 + Live | high |
+| 15 | `GetWordstatReport` | v4 + Live | high |
+| 16 | `GetWordstatReportList` | v4 + Live | high |
+| 17 | `PayCampaigns` | v4 + Live | high |
+| 18 | `PayCampaignsByCard` | v4 + Live | high |
+| 19 | `TransferMoney` | v4 + Live | high |
+| 20 | `AdImageAssociation` | Live only | medium |
+| 21 | `CheckPayment` | v4 + Live | medium |
+| 22 | `DeleteOfflineReport` | Live only | medium |
+| 23 | `DeleteReport` | v4 + Live | medium |
+| 24 | `GetAvailableVersions` | v4 + Live | low |
+| 25 | `GetBannersTags` | Live only | medium |
+| 26 | `GetCampaignsTags` | Live only | medium |
+| 27 | `GetKeywordsSuggestion` | v4 + Live | medium |
+| 28 | `GetVersion` | v4 + Live | low |
+| 29 | `PingAPI` | v4 + Live | low |
+| 30 | `PingAPI_X` | v4 + Live | low |
+| 31 | `UpdateBannersTags` | Live only | medium |
+| 32 | `UpdateCampaignsTags` | Live only | medium |
+
+## Removed from v4 Live
+
+These operations are still present in the WSDL but Yandex disabled them server-side. Calling them returns `V4LiveError(error_code=509)`. Use the v5 client (`YandexDirect`) for the equivalent functionality.
+
+- `GetBalance` (v4 + Live)

--- a/scripts/audit_wsdl.py
+++ b/scripts/audit_wsdl.py
@@ -179,7 +179,6 @@ V4_TO_V5_MAP: dict[str, str | None] = {
     "GetKeywordsSuggestion":  None,
     # ===== CANDIDATES FOR IMPLEMENTATION (no v5 equivalent) =====
     "GetClientsUnits":        None,  # client points balance — v4-only
-    "GetBalance":             None,  # campaign balance — v4-only
     "GetCreditLimits":        None,
     "TransferMoney":          None,
     "PayCampaigns":           None,
@@ -204,7 +203,7 @@ V4_TO_V5_MAP: dict[str, str | None] = {
 # Methods explicitly mentioned by the issue author as relevant / actual.
 # Used to bump priority of unmapped methods to "high".
 V4_HIGH_PRIORITY_HINTS: frozenset[str] = frozenset({
-    "GetBalance", "GetClientsUnits", "GetCreditLimits",
+    "GetClientsUnits", "GetCreditLimits",
     "TransferMoney", "PayCampaigns", "PayCampaignsByCard",
     "CreateInvoice", "AccountManagement", "EnableSharedAccount",
     "GetEventsLog", "GetStatGoals", "GetRetargetingGoals",
@@ -222,16 +221,29 @@ V4_NO_BUSINESS_VALUE: frozenset[str] = frozenset({
     "PingAPI", "PingAPI_X", "GetVersion", "GetAvailableVersions",
 })
 
+# Methods that still appear in the v4 / v4 Live WSDL but have been disabled
+# server-side by Yandex — calls return error_code=509
+# ("This method is not available in this API version"). Verified live
+# 2026-04-27. Keep here so the matrix can surface them honestly instead of
+# advertising them as implementation candidates. v5 alternatives noted in
+# README.
+V4_REMOVED_FROM_LIVE: frozenset[str] = frozenset({
+    "GetBalance",
+})
+
 
 def classify_v4_method(method: str) -> tuple[str, str | None]:
     """Classify a v4 / v4 Live operation against v5.
 
     Returns a (status, v5_equivalent) tuple. Status is one of:
+      - "removed_from_v4_live" — method was disabled server-side (error_code 509).
       - "deprecated_with_v5_replacement" — method has a direct v5 analogue.
       - "actual_no_v5_analogue" — method is in V4_TO_V5_MAP with value None
         (= explicitly classified as "no v5 equivalent, candidate to implement").
       - "unclassified" — method is missing from V4_TO_V5_MAP entirely.
     """
+    if method in V4_REMOVED_FROM_LIVE:
+        return ("removed_from_v4_live", None)
     if method not in V4_TO_V5_MAP:
         return ("unclassified", None)
     v5_eq = V4_TO_V5_MAP[method]
@@ -242,6 +254,8 @@ def classify_v4_method(method: str) -> tuple[str, str | None]:
 
 def v4_method_priority(method: str, status: str) -> str:
     """Return priority label for a v4 method."""
+    if status == "removed_from_v4_live":
+        return "skip"
     if status == "actual_no_v5_analogue":
         if method in V4_NO_BUSINESS_VALUE:
             return "low"
@@ -885,6 +899,7 @@ def build_v4_matrix(v4_services: list[DiscoveredService]) -> str:
     n_actual = sum(1 for r in rows if r["status"] == "actual_no_v5_analogue")
     n_dep = sum(1 for r in rows if r["status"] == "deprecated_with_v5_replacement")
     n_unclassified = sum(1 for r in rows if r["status"] == "unclassified")
+    n_removed = sum(1 for r in rows if r["status"] == "removed_from_v4_live")
     n_high = sum(1 for r in rows if r["priority"] == "high")
     n_medium = sum(1 for r in rows if r["priority"] == "medium")
 
@@ -899,6 +914,7 @@ def build_v4_matrix(v4_services: list[DiscoveredService]) -> str:
         "Status semantics:",
         "- **deprecated_with_v5_replacement** — direct v5 analogue exists; new code should use v5.",
         "- **actual_no_v5_analogue** — no v5 equivalent; candidate for implementation in this library.",
+        "- **removed_from_v4_live** — operation is in the WSDL but Yandex disabled it server-side (error_code 509); use the v5 client.",
         "- **unclassified** — not yet classified in `V4_TO_V5_MAP`; needs review.",
         "",
         "## Summary",
@@ -911,6 +927,7 @@ def build_v4_matrix(v4_services: list[DiscoveredService]) -> str:
         f"| Operations available only in v4 (not Live) | {sum(1 for r in rows if r['availability'] == 'v4 only')} |",
         f"| Status: deprecated_with_v5_replacement | {n_dep} |",
         f"| Status: actual_no_v5_analogue (candidates) | {n_actual} |",
+        f"| Status: removed_from_v4_live | {n_removed} |",
         f"| Status: unclassified (needs review) | {n_unclassified} |",
         f"| Priority: high (issue-mentioned candidates) | {n_high} |",
         f"| Priority: medium (other actual candidates) | {n_medium} |",
@@ -945,6 +962,20 @@ def build_v4_matrix(v4_services: list[DiscoveredService]) -> str:
             )
     else:
         lines.append("_No candidates — every method is either deprecated or unclassified._")
+
+    if n_removed > 0:
+        lines += [
+            "",
+            "## Removed from v4 Live",
+            "",
+            "These operations are still present in the WSDL but Yandex disabled them "
+            "server-side. Calling them returns `V4LiveError(error_code=509)`. "
+            "Use the v5 client (`YandexDirect`) for the equivalent functionality.",
+            "",
+        ]
+        for row in rows:
+            if row["status"] == "removed_from_v4_live":
+                lines.append(f"- `{row['method']}` ({row['availability']})")
 
     if n_unclassified > 0:
         lines += [

--- a/tapi_yandex_direct/v4/resource_mapping.py
+++ b/tapi_yandex_direct/v4/resource_mapping.py
@@ -18,9 +18,10 @@ RESOURCE_MAPPING_V4_LIVE = {
 
 
 SUPPORTED_V4_METHODS: dict[str, dict] = {
-    # Finance — high priority candidates from the matrix
+    # Finance — high priority candidates from the matrix.
+    # Note: GetBalance was removed by Yandex from v4 Live (error_code 509);
+    # use the v5 client and read campaigns.get → Funds instead.
     "GetClientsUnits":         {"group": "finance"},
-    "GetBalance":              {"group": "finance"},
     "GetCreditLimits":         {"group": "finance"},
     "TransferMoney":           {"group": "finance"},
     "PayCampaigns":            {"group": "finance"},

--- a/tests/test_audit_wsdl.py
+++ b/tests/test_audit_wsdl.py
@@ -297,7 +297,7 @@ def test_classify_v4_method_returns_unclassified_for_unknown():
 
 def test_v4_method_priority_high_for_issue_mentioned_actual():
     assert audit_wsdl.v4_method_priority(
-        "GetBalance", "actual_no_v5_analogue"
+        "GetClientsUnits", "actual_no_v5_analogue"
     ) == "high"
     # An actual method NOT in the issue hints AND not in V4_NO_BUSINESS_VALUE
     # should be medium. AdImageAssociation maps to None, is not in hints, and
@@ -321,8 +321,8 @@ def test_discover_v4_wsdl_services_uses_monolithic_endpoints(monkeypatch):
     def fake_fetch(url, timeout):
         fetched.append(url)
         if "live" in url:
-            return ({"GetEventsLog", "AccountManagement", "GetBalance"}, True)
-        return ({"GetBalance", "GetCampaignsList"}, True)
+            return ({"GetEventsLog", "AccountManagement", "GetClientsUnits"}, True)
+        return ({"GetClientsUnits", "GetCampaignsList"}, True)
 
     monkeypatch.setattr(audit_wsdl, "fetch_wsdl_operations", fake_fetch)
 
@@ -332,15 +332,15 @@ def test_discover_v4_wsdl_services_uses_monolithic_endpoints(monkeypatch):
     assert [s.version for s in services] == ["v4", "v4live"]
     assert services[0].wsdl_url == audit_wsdl.V4_WSDL_URL
     assert services[1].wsdl_url == audit_wsdl.V4_LIVE_WSDL_URL
-    assert services[0].methods == {"GetBalance", "GetCampaignsList"}
-    assert services[1].methods == {"GetEventsLog", "AccountManagement", "GetBalance"}
+    assert services[0].methods == {"GetClientsUnits", "GetCampaignsList"}
+    assert services[1].methods == {"GetEventsLog", "AccountManagement", "GetClientsUnits"}
 
 
 def test_discover_v4_wsdl_services_skips_unavailable(monkeypatch, capsys):
     def fake_fetch(url, timeout):
         if "live" in url:
             return (set(), False)
-        return ({"GetBalance"}, True)
+        return ({"GetClientsUnits"}, True)
 
     monkeypatch.setattr(audit_wsdl, "fetch_wsdl_operations", fake_fetch)
 
@@ -358,7 +358,7 @@ def test_build_v4_matrix_includes_priority_and_v5_equivalent():
         name="v4",
         endpoint="v4_monolithic",
         docs_url="",
-        methods={"GetCampaignsList", "GetBalance"},
+        methods={"GetCampaignsList", "GetClientsUnits", "GetBalance"},
         wsdl_url=audit_wsdl.V4_WSDL_URL,
         soap_url="https://api.direct.yandex.ru/v4/",
         json_url=None,
@@ -368,7 +368,10 @@ def test_build_v4_matrix_includes_priority_and_v5_equivalent():
         name="v4live",
         endpoint="v4_live_monolithic",
         docs_url="",
-        methods={"GetCampaignsList", "GetBalance", "AccountManagement", "BogusUnclassifiedOp"},
+        methods={
+            "GetCampaignsList", "GetClientsUnits", "GetBalance",
+            "AccountManagement", "BogusUnclassifiedOp",
+        },
         wsdl_url=audit_wsdl.V4_LIVE_WSDL_URL,
         soap_url="https://api.direct.yandex.ru/live/v4/",
         json_url=None,
@@ -383,10 +386,14 @@ def test_build_v4_matrix_includes_priority_and_v5_equivalent():
     assert "deprecated_with_v5_replacement" in matrix
     assert "low" in matrix
     # Actual + high priority (issue-mentioned)
-    assert "`GetBalance`" in matrix
+    assert "`GetClientsUnits`" in matrix
     assert "actual_no_v5_analogue" in matrix
     assert "high" in matrix
     assert "`AccountManagement`" in matrix
+    # GetBalance — removed by Yandex from v4 Live, surfaces in its own section
+    assert "`GetBalance`" in matrix
+    assert "removed_from_v4_live" in matrix
+    assert "Removed from v4 Live" in matrix
     # Availability column
     assert "v4 + Live" in matrix
     assert "Live only" in matrix
@@ -433,13 +440,26 @@ def test_v4_to_v5_map_covers_all_known_v4_live_operations():
         "UpdateBannersTags", "UpdateCampaignsTags", "UpdateClientInfo",
         "UpdatePrices",
     }
-    missing = known_v4_live_ops - set(audit_wsdl.V4_TO_V5_MAP)
+    classified = set(audit_wsdl.V4_TO_V5_MAP) | set(audit_wsdl.V4_REMOVED_FROM_LIVE)
+    missing = known_v4_live_ops - classified
     assert not missing, (
-        f"V4_TO_V5_MAP must classify every known v4 / v4 Live WSDL operation. "
-        f"Add entries for: {sorted(missing)}"
+        f"Every known v4 / v4 Live WSDL operation must be classified — either "
+        f"in V4_TO_V5_MAP or in V4_REMOVED_FROM_LIVE. Missing: {sorted(missing)}"
     )
-    extra = set(audit_wsdl.V4_TO_V5_MAP) - known_v4_live_ops
+    extra = classified - known_v4_live_ops
     assert not extra, (
-        f"V4_TO_V5_MAP contains entries not in known_v4_live_ops "
-        f"(possible typos in keys): {sorted(extra)}"
+        f"V4_TO_V5_MAP / V4_REMOVED_FROM_LIVE contain entries not in "
+        f"known_v4_live_ops (possible typos in keys): {sorted(extra)}"
     )
+
+
+def test_classify_v4_method_returns_removed_for_disabled_method():
+    # GetBalance is still in the v4 / v4 Live WSDL, but Yandex disabled it
+    # server-side (returns error_code 509). It must be surfaced via its own
+    # status, not silently treated as a candidate.
+    status, v5_eq = audit_wsdl.classify_v4_method("GetBalance")
+    assert status == "removed_from_v4_live"
+    assert v5_eq is None
+    assert audit_wsdl.v4_method_priority(
+        "GetBalance", "removed_from_v4_live"
+    ) == "skip"

--- a/tests/test_audit_wsdl.py
+++ b/tests/test_audit_wsdl.py
@@ -451,6 +451,15 @@ def test_v4_to_v5_map_covers_all_known_v4_live_operations():
         f"V4_TO_V5_MAP / V4_REMOVED_FROM_LIVE contain entries not in "
         f"known_v4_live_ops (possible typos in keys): {sorted(extra)}"
     )
+    # The two sets must be disjoint. classify_v4_method silently prefers
+    # V4_REMOVED_FROM_LIVE on overlap, so without this guard a method
+    # accidentally re-added to V4_TO_V5_MAP would still classify as
+    # "removed_from_v4_live" and the desync would go unnoticed.
+    overlap = set(audit_wsdl.V4_TO_V5_MAP) & set(audit_wsdl.V4_REMOVED_FROM_LIVE)
+    assert not overlap, (
+        f"Methods must not appear in both V4_TO_V5_MAP and "
+        f"V4_REMOVED_FROM_LIVE: {sorted(overlap)}"
+    )
 
 
 def test_classify_v4_method_returns_removed_for_disabled_method():

--- a/tests/test_v4_live.py
+++ b/tests/test_v4_live.py
@@ -18,7 +18,7 @@ V4_LIVE_SANDBOX_URL = "https://api-sandbox.direct.yandex.ru/live/v4/json/"
 def _make_client(**overrides):
     defaults = dict(
         access_token="test-token",
-        login="ksamatadirect",
+        login="test-login",
         is_sandbox=False,
         language="en",
         retry_if_exceeded_limit=False,
@@ -38,14 +38,14 @@ def test_v4live_post_success_returns_data():
     responses.add(
         responses.POST,
         V4_LIVE_URL,
-        json={"data": [{"UnitsRest": 32000, "Login": "ksamatadirect"}]},
+        json={"data": [{"UnitsRest": 32000, "Login": "test-login"}]},
         status=200,
     )
     client = _make_client()
     result = client.v4live().post(
-        data={"method": "GetClientsUnits", "param": ["ksamatadirect"]}
+        data={"method": "GetClientsUnits", "param": ["test-login"]}
     )
-    assert result.data == {"data": [{"UnitsRest": 32000, "Login": "ksamatadirect"}]}
+    assert result.data == {"data": [{"UnitsRest": 32000, "Login": "test-login"}]}
 
 
 @responses.activate

--- a/tests/test_v4_live_integration.py
+++ b/tests/test_v4_live_integration.py
@@ -1,10 +1,11 @@
 """Optional live integration tests for v4 Live JSON client.
 
-Skipped automatically unless ``YANDEX_DIRECT_TOKEN`` is in the environment, so
-CI never hits the real API. Run locally with::
+Skipped automatically unless both ``YANDEX_DIRECT_TOKEN`` and
+``YANDEX_DIRECT_LOGIN`` are in the environment, so CI never hits the real API.
+Run locally with::
 
     export YANDEX_DIRECT_TOKEN=...   (real OAuth token)
-    export YANDEX_DIRECT_LOGIN=...   (account login, defaults to ksamatadirect)
+    export YANDEX_DIRECT_LOGIN=...   (account login)
     pytest tests/test_v4_live_integration.py -v -m live
 
 The probes intentionally cover only **read-only** v4 Live operations and one
@@ -20,8 +21,11 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 pytestmark = pytest.mark.skipif(
-    not os.environ.get("YANDEX_DIRECT_TOKEN"),
-    reason="set YANDEX_DIRECT_TOKEN to run against the real Yandex Direct API",
+    not (os.environ.get("YANDEX_DIRECT_TOKEN") and os.environ.get("YANDEX_DIRECT_LOGIN")),
+    reason=(
+        "set both YANDEX_DIRECT_TOKEN and YANDEX_DIRECT_LOGIN "
+        "to run against the real Yandex Direct API"
+    ),
 )
 
 
@@ -29,7 +33,7 @@ pytestmark = pytest.mark.skipif(
 def v4_kwargs() -> dict:
     return {
         "access_token": os.environ["YANDEX_DIRECT_TOKEN"],
-        "login": os.environ.get("YANDEX_DIRECT_LOGIN", "ksamatadirect"),
+        "login": os.environ["YANDEX_DIRECT_LOGIN"],
     }
 
 
@@ -137,9 +141,12 @@ def test_get_campaigns_tags(v4_client, real_ids):
         "param": {"CampaignIDS": [real_ids["campaign_id"]]},
     })
     extracted = res().extract()
-    assert isinstance(extracted, list) and extracted
-    assert extracted[0]["CampaignID"] == real_ids["campaign_id"]
-    assert "Tags" in extracted[0]
+    # Empty list is a valid response (campaign has no tags) — only assert
+    # element shape when something came back.
+    assert isinstance(extracted, list)
+    if extracted:
+        assert extracted[0]["CampaignID"] == real_ids["campaign_id"]
+        assert "Tags" in extracted[0]
 
 
 @pytest.mark.live
@@ -152,8 +159,10 @@ def test_get_banners_tags(v4_client, real_ids):
         "param": {"BannerIDS": [real_ids["banner_id"]]},
     })
     extracted = res().extract()
-    assert isinstance(extracted, list) and extracted
-    assert extracted[0]["BannerID"] == real_ids["banner_id"]
+    # Empty list is valid (banner has no tags).
+    assert isinstance(extracted, list)
+    if extracted:
+        assert extracted[0]["BannerID"] == real_ids["banner_id"]
 
 
 # ------- methods with non-trivial schemas -------

--- a/tests/test_v4_live_integration.py
+++ b/tests/test_v4_live_integration.py
@@ -1,13 +1,21 @@
-"""Optional live integration test for v4 Live JSON client.
+"""Optional live integration tests for v4 Live JSON client.
 
-Skipped automatically unless YANDEX_DIRECT_TOKEN is in the environment, so CI
-never hits the real API. Run locally with:
+Skipped automatically unless ``YANDEX_DIRECT_TOKEN`` is in the environment, so
+CI never hits the real API. Run locally with::
 
     export YANDEX_DIRECT_TOKEN=...   (real OAuth token)
     export YANDEX_DIRECT_LOGIN=...   (account login, defaults to ksamatadirect)
     pytest tests/test_v4_live_integration.py -v -m live
+
+The probes intentionally cover only **read-only** v4 Live operations and one
+schema-only check for ``CheckPayment``. They double as living documentation of
+the correct request shapes — call schemas come from the official Yandex Direct
+v4 Live docs (https://yandex.com/dev/direct/doc/dg-v4/en/live/...).
 """
+from __future__ import annotations
+
 import os
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -17,21 +25,185 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-@pytest.mark.live
-def test_get_clients_units_live():
-    from tapi_yandex_direct import YandexDirectV4Live
+@pytest.fixture(scope="module")
+def v4_kwargs() -> dict:
+    return {
+        "access_token": os.environ["YANDEX_DIRECT_TOKEN"],
+        "login": os.environ.get("YANDEX_DIRECT_LOGIN", "ksamatadirect"),
+    }
 
-    login = os.environ.get("YANDEX_DIRECT_LOGIN", "ksamatadirect")
-    client = YandexDirectV4Live(
-        access_token=os.environ["YANDEX_DIRECT_TOKEN"],
-        login=login,
-    )
-    result = client.v4live().post(
-        data={"method": "GetClientsUnits", "param": [login]}
-    )
-    extracted = result().extract()
+
+@pytest.fixture(scope="module")
+def v4_client(v4_kwargs):
+    from tapi_yandex_direct import YandexDirectV4Live
+    return YandexDirectV4Live(**v4_kwargs)
+
+
+@pytest.fixture(scope="module")
+def real_ids(v4_kwargs) -> dict:
+    """Resolve a real CampaignID and BannerID via the v5 client.
+
+    v4 Live tag/goal probes need real entities; v5 is the cleanest source.
+    """
+    from tapi_yandex_direct import YandexDirect
+
+    v5 = YandexDirect(**v4_kwargs)
+    camps = v5.campaigns().post(data={
+        "method": "get",
+        "params": {
+            "SelectionCriteria": {},
+            "FieldNames": ["Id"],
+            "Page": {"Limit": 1},
+        },
+    })
+    camp_list = camps().extract()
+    if not camp_list:
+        pytest.skip("account has no campaigns to probe against")
+    cid: int = camp_list[0]["Id"]
+
+    ads = v5.ads().post(data={
+        "method": "get",
+        "params": {
+            "SelectionCriteria": {"CampaignIds": [cid]},
+            "FieldNames": ["Id"],
+            "Page": {"Limit": 1},
+        },
+    })
+    ads_list = ads().extract()
+    bid = ads_list[0]["Id"] if ads_list else None
+    return {"campaign_id": cid, "banner_id": bid}
+
+
+# ------- methods that work without any real entity -------
+
+@pytest.mark.live
+def test_get_clients_units(v4_client, v4_kwargs):
+    res = v4_client.v4live().post(data={
+        "method": "GetClientsUnits", "param": [v4_kwargs["login"]],
+    })
+    extracted = res().extract()
+    assert isinstance(extracted, list) and extracted
+    assert extracted[0]["Login"] == v4_kwargs["login"]
+    assert isinstance(extracted[0]["UnitsRest"], int)
+
+
+@pytest.mark.live
+def test_get_retargeting_goals(v4_client, v4_kwargs):
+    res = v4_client.v4live().post(data={
+        "method": "GetRetargetingGoals", "param": {"Login": v4_kwargs["login"]},
+    })
+    goals = res().extract()
+    assert isinstance(goals, list)
+    if goals:
+        assert "GoalID" in goals[0]
+
+
+@pytest.mark.live
+@pytest.mark.parametrize("method", [
+    "GetWordstatReportList",
+    "GetForecastList",
+    "PingAPI",
+    "GetVersion",
+    "GetAvailableVersions",
+])
+def test_methods_with_empty_param(v4_client, method):
+    res = v4_client.v4live().post(data={"method": method, "param": []})
+    # All five succeed; payload shape varies (list/int/list-of-versions),
+    # we only assert no exception and that data field is present.
+    assert "data" in res.data
+
+
+# ------- methods that need a real CampaignID / BannerID -------
+
+@pytest.mark.live
+def test_get_stat_goals(v4_client, real_ids):
+    """Per docs: GetStatGoals takes ``CampaignIDS`` (array), not ``CampaignID``."""
+    res = v4_client.v4live().post(data={
+        "method": "GetStatGoals",
+        "param": {"CampaignIDS": [real_ids["campaign_id"]]},
+    })
+    extracted = res().extract()
     assert isinstance(extracted, list)
-    assert extracted, "expected at least one entry in GetClientsUnits response"
-    entry = extracted[0]
-    assert entry["Login"]
-    assert isinstance(entry["UnitsRest"], int)
+    if extracted:
+        assert "GoalID" in extracted[0]
+        assert extracted[0]["CampaignID"] == real_ids["campaign_id"]
+
+
+@pytest.mark.live
+def test_get_campaigns_tags(v4_client, real_ids):
+    """Per docs: ``CampaignIDS`` (capital S), not ``CampaignIDs``."""
+    res = v4_client.v4live().post(data={
+        "method": "GetCampaignsTags",
+        "param": {"CampaignIDS": [real_ids["campaign_id"]]},
+    })
+    extracted = res().extract()
+    assert isinstance(extracted, list) and extracted
+    assert extracted[0]["CampaignID"] == real_ids["campaign_id"]
+    assert "Tags" in extracted[0]
+
+
+@pytest.mark.live
+def test_get_banners_tags(v4_client, real_ids):
+    """Per docs: ``BannerIDS`` (capital S)."""
+    if real_ids["banner_id"] is None:
+        pytest.skip("account campaign has no ads to probe")
+    res = v4_client.v4live().post(data={
+        "method": "GetBannersTags",
+        "param": {"BannerIDS": [real_ids["banner_id"]]},
+    })
+    extracted = res().extract()
+    assert isinstance(extracted, list) and extracted
+    assert extracted[0]["BannerID"] == real_ids["banner_id"]
+
+
+# ------- methods with non-trivial schemas -------
+
+@pytest.mark.live
+def test_get_events_log(v4_client):
+    """Per docs: TimestampFrom must be ISO 8601 AND Currency is required."""
+    ts = (datetime.now(timezone.utc) - timedelta(days=7)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    res = v4_client.v4live().post(data={
+        "method": "GetEventsLog",
+        "param": {"TimestampFrom": ts, "Currency": "RUB", "Limit": 3},
+    })
+    events = res().extract()
+    assert isinstance(events, list)
+
+
+@pytest.mark.live
+def test_get_keywords_suggestion(v4_client):
+    """Per docs: parameter name is ``Keywords`` (a list of phrases)."""
+    res = v4_client.v4live().post(data={
+        "method": "GetKeywordsSuggestion",
+        "param": {"Keywords": ["купить смартфон"]},
+    })
+    suggestions = res().extract()
+    assert isinstance(suggestions, list)
+
+
+# ------- schema-only checks: we verify the adapter doesn't crash -------
+
+@pytest.mark.live
+def test_check_payment_schema_only(v4_client):
+    """CheckPayment requires real CustomTransactionID; we send a placeholder
+    and expect a structured V4LiveError, not a Python exception."""
+    from tapi_yandex_direct import exceptions as exc
+    with pytest.raises(exc.V4LiveError) as info:
+        v4_client.v4live().post(data={
+            "method": "CheckPayment",
+            "param": {"OperationNum": 1, "CustomTransactionID": "probe-not-real"},
+        })
+    assert info.value.error_code != 0
+
+
+@pytest.mark.live
+def test_get_credit_limits_requires_finance_token(v4_client):
+    """GetCreditLimits requires a separate finance OAuth token. With a regular
+    access_token Yandex returns ``error_code=350``."""
+    from tapi_yandex_direct import exceptions as exc
+    with pytest.raises(exc.V4LiveError) as info:
+        v4_client.v4live().post(data={
+            "method": "GetCreditLimits", "param": [],
+        })
+    # 350 = "Invalid financial transaction token"
+    assert info.value.error_code == 350


### PR DESCRIPTION
Closes #18.

After mergiing #17 I ran every read-only method from `SUPPORTED_V4_METHODS` against the real `ksamatadirect` account. 9 of 16 failed. Cross-checked every parameter schema against the official Yandex docs (https://yandex.com/dev/direct/doc/dg-v4/en/live/...). **The adapter does not need any changes** — every failure was either a wrong field name on my side or a method Yandex disabled server-side.

## Changes

### `GetBalance` removed from supported set

Yandex disabled `GetBalance` in v4 Live (error_code 509). Drop it from `SUPPORTED_V4_METHODS` and surface honestly:

- New `V4_REMOVED_FROM_LIVE = {\"GetBalance\"}` in `scripts/audit_wsdl.py`.
- Fourth status `removed_from_v4_live` with priority `skip` in `classify_v4_method` / `v4_method_priority`.
- Dedicated **\"Removed from v4 Live\"** section in `build_v4_matrix` and the regenerated `docs/v4_methods_matrix.md`.
- Bidirectional coverage guard now allows ops to be classified in either `V4_TO_V5_MAP` or `V4_REMOVED_FROM_LIVE`.

### Integration probes — 14/14 passed live

Replaced the single-method live test with a parameterised set covering every read-only operation:

| Method | What got fixed |
|---|---|
| `GetClientsUnits` | already worked |
| `GetRetargetingGoals` | already worked |
| `GetWordstatReportList` / `GetForecastList` / `PingAPI` / `GetVersion` / `GetAvailableVersions` | empty `param` → 200 |
| `GetStatGoals` | uses `CampaignIDS` array, not `CampaignID` |
| `GetCampaignsTags` | uses `CampaignIDS` (capital S), not `CampaignIDs` |
| `GetBannersTags` | uses `BannerIDS` (capital S) |
| `GetEventsLog` | needs both ISO 8601 `TimestampFrom` AND a required `Currency` |
| `GetKeywordsSuggestion` | parameter is `Keywords` (not `Phrases`) |
| `CheckPayment` | schema-only — verifies the adapter raises `V4LiveError` cleanly without a Python crash |
| `GetCreditLimits` | documents the `error_code=350` finance-token path |

A `real_ids` fixture pulls a real `CampaignID`/`BannerID` from the v5 client so the tag/goal probes have something to work against.

### README

New sections under `## v4 Live API`:

- **Methods removed from v4 Live by Yandex** — with the v5 `campaigns.get → Funds` workaround for `GetBalance`.
- **Finance methods (financial_token required)** — explains the `error_code=350` path and points to the official finance docs.
- **Common request schemas** — table with the verified `param` shape for the 7 trickiest methods.

## Verification

```bash
pytest tests/                                         # 43 passed, 14 skipped (live)
python scripts/audit_wsdl.py --versions v4 --v4-matrix docs/v4_methods_matrix.md

# Live (token from sibling .env)
export YANDEX_DIRECT_TOKEN=...
export YANDEX_DIRECT_LOGIN=...
pytest tests/test_v4_live_integration.py -v -m live   # 14 passed locally
```

## Out of scope

- Building the OAuth-derived `financial_token` ourselves — separate task, requires client_secret + operation_num flow.
- High-level helpers like `client.balance()` / `client.transfer_money(...)`.
- Wordstat / Forecast polling helpers.