### PR TITLE
fix: preserve v4 Live Client-Login header contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,8 @@ docs/_build
 
 # Git worktrees
 .worktrees/
+
+# Local agent files
+.claude/
+AGENTS.md
+CLAUDE.md

--- a/tapi_yandex_direct/__init__.py
+++ b/tapi_yandex_direct/__init__.py
@@ -1,7 +1,7 @@
 
 __author__ = 'Pavel Maksimov'
 __email__ = 'vur21@ya.ru'
-__version__ = '2026.4.27'
+__version__ = '2026.4.28'
 
 
 from .resource_mapping import *

--- a/tapi_yandex_direct/v4/adapter.py
+++ b/tapi_yandex_direct/v4/adapter.py
@@ -44,9 +44,10 @@ class V4LiveClientAdapter(JSONAdapterMixin, TapiAdapter):
         login = api_params.get("login")
         language = api_params.get("language", "en")
 
-        # Enrich the JSON body with token / locale / login (param.login for
-        # agent calls). format_data_to_request does not see api_params, so we
-        # do this here, after super() has already serialised the user data.
+        # Enrich the JSON body with token / locale. format_data_to_request does
+        # not see api_params, so we do this here, after super() has already
+        # serialised the user data. Agency/client selection is transport-level
+        # (Client-Login header); method params must stay schema-shaped.
         raw = params.get("data")
         if raw:
             if isinstance(raw, (bytes, bytearray)):
@@ -66,13 +67,14 @@ class V4LiveClientAdapter(JSONAdapterMixin, TapiAdapter):
                 body.setdefault("token", token)
             if language:
                 body.setdefault("locale", language)
-            if login and isinstance(body.get("param"), dict):
-                body["param"].setdefault("login", login)
 
             params["data"] = orjson.dumps(body)
 
         if token:
             params["headers"]["Authorization"] = "Bearer {}".format(token)
+
+        if login:
+            params["headers"]["Client-Login"] = login
 
         return params
 

--- a/tests/test_v4_live.py
+++ b/tests/test_v4_live.py
@@ -79,14 +79,31 @@ def test_v4live_default_locale_is_en():
 
 
 @responses.activate
-def test_v4live_login_injected_into_param_dict():
+def test_v4live_login_sent_as_header_without_mutating_param_dict():
     responses.add(responses.POST, V4_LIVE_URL, json={"data": []}, status=200)
     client = _make_client(login="agent@yandex")
     client.v4live().post(
-        data={"method": "GetEventsLog", "param": {"TimestampFrom": 1714200000}}
+        data={"method": "GetStatGoals", "param": {"CampaignIDS": [123]}}
     )
+    sent = responses.calls[-1].request
     body = _last_request_body()
-    assert body["param"]["login"] == "agent@yandex"
+    assert sent.headers["Client-Login"] == "agent@yandex"
+    assert body["param"] == {"CampaignIDS": [123]}
+    assert "login" not in body["param"]
+
+
+@responses.activate
+def test_v4live_login_header_preserves_account_management_param():
+    responses.add(responses.POST, V4_LIVE_URL, json={"data": []}, status=200)
+    client = _make_client(login="agent@yandex")
+    client.v4live().post(
+        data={"method": "AccountManagement", "param": {"Action": "Get"}}
+    )
+    sent = responses.calls[-1].request
+    body = _last_request_body()
+    assert sent.headers["Client-Login"] == "agent@yandex"
+    assert body["param"] == {"Action": "Get"}
+    assert "login" not in body["param"]
 
 
 @responses.activate
@@ -95,6 +112,7 @@ def test_v4live_login_not_injected_when_param_is_list():
     client = _make_client(login="agent@yandex")
     client.v4live().post(data={"method": "GetClientsUnits", "param": ["sub"]})
     # param remains a list; login does not get pushed in
+    assert responses.calls[-1].request.headers["Client-Login"] == "agent@yandex"
     assert _last_request_body()["param"] == ["sub"]
 
 


### PR DESCRIPTION
## Summary
- send configured v4 Live login through the Client-Login header
- keep method param payloads schema-shaped and unmutated
- add mocked regression coverage for dict and list param shapes

## Tests
- python3 -m pytest tests/test_v4_live.py -q