### PR TITLE
[codex] Add v4 JSON docs audit

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,4 +27,11 @@ jobs:
         run: pip install -e . responses pytest
 
       - name: Run tests
-        run: pytest tests/tests.py -v
+        run: >
+          pytest
+          tests/tests.py
+          tests/test_resource_mapping.py
+          tests/test_v4_live.py
+          tests/test_v4_json_docs.py
+          tests/test_audit_wsdl.py
+          -v

--- a/README.md
+++ b/README.md
@@ -471,8 +471,9 @@ client = YandexDirectV4Live(
 ### Request shape
 
 v4 Live is RPC-style: there is **one endpoint** and the operation name lives in
-the JSON body. The client injects the OAuth token, locale, and login (for
-`param: dict` payloads only) automatically — pass `method` and `param`:
+the JSON body. The client injects the OAuth token, locale, and `Client-Login`
+header automatically. It does not rewrite method-specific `param` payloads —
+pass the exact `method` and `param` shape from the v4 JSON docs:
 
 ```python
 # Read-only: rate-limit units balance for the account
@@ -483,10 +484,10 @@ result = client.v4live().post(data={
 result.data        # → {"data": [{"UnitsRest": 32000, "Login": "..."}]}
 result().extract() # → [{"UnitsRest": 32000, "Login": "..."}]
 
-# Method with dict params (login auto-injected from client config)
+# Method with dict params
 result = client.v4live().post(data={
     "method": "GetEventsLog",
-    "param": {"TimestampFrom": 1714200000, "Limit": 100},
+    "param": {"TimestampFrom": "2026-04-28T00:00:00Z", "Currency": "RUB", "Limit": 100},
 })
 ```
 
@@ -570,23 +571,25 @@ the verified live-API behaviour of every supported method.
 
 ### Common request schemas
 
-The full call schemas come from
-<https://yandex.com/dev/direct/doc/dg-v4/en/live/concepts>. A few that trip
-up newcomers (verified live):
+The full call schemas come from the local
+`docs/v4_json_contracts.json` snapshot of official v4 JSON docs. Refresh that
+snapshot manually with `python3 scripts/audit_v4_json_docs.py --refresh-from-online --output docs/v4_json_contracts.json`.
+A few fields that trip up newcomers:
 
 | Method | Required `param` shape |
 |---|---|
 | `GetClientsUnits` | list of logins, e.g. `["my-login"]` |
-| `GetRetargetingGoals` | `{"Login": "my-login"}` |
+| `GetRetargetingGoals` (Live) | `{"Logins": ["my-login", ...]}` |
+| `GetStatGoals` (v4 reference) | `{"CampaignID": <int>}` |
 | `GetStatGoals` | `{"CampaignIDS": [<int>, ...]}` (capital S) |
 | `GetCampaignsTags` | `{"CampaignIDS": [<int>, ...]}` |
 | `GetBannersTags` | `{"BannerIDS": [<int>, ...]}` |
 | `GetEventsLog` | `{"TimestampFrom": "<ISO 8601>", "Currency": "RUB"\|"USD"\|...}` |
 | `GetKeywordsSuggestion` | `{"Keywords": ["phrase 1", ...]}` |
 
-`tests/test_v4_live_integration.py` exercises each of these against the real
-API as living documentation — run with `pytest -m live` and a token in
-`YANDEX_DIRECT_TOKEN`.
+`tests/test_v4_json_docs.py` is the offline contract audit. Optional live
+probes in `tests/test_v4_live_integration.py` only confirm API behavior — run
+with `pytest -m live` and a token in `YANDEX_DIRECT_TOKEN`.
 
 
 ## Features

--- a/docs/v4_json_contracts.json
+++ b/docs/v4_json_contracts.json
@@ -1,0 +1,355 @@
+{
+  "metadata": {
+    "schema_version": 1,
+    "generated_at": "2026-04-28",
+    "source": "Manual snapshot of official Yandex Direct API v4 JSON documentation. WSDL is used only for operation availability.",
+    "json_protocol_url": "https://yandex.com/dev/direct/doc/dg-v4/en/concepts/JSON",
+    "versions_url": "https://yandex.com/dev/direct/doc/dg-v4/en/concepts/Versions"
+  },
+  "contracts": [
+    {
+      "method": "AccountManagement",
+      "variant": "live",
+      "source_url": "https://yandex.com/dev/direct/doc/dg-v4/en/live/AccountManagement",
+      "request": {"method": "AccountManagement"},
+      "param_shape": "object",
+      "param_fields": [{"name": "Action", "required": true}],
+      "required_fields": ["Action"],
+      "notes": ["Shared-account action object. Client-Login stays in the HTTP header."]
+    },
+    {
+      "method": "AdImageAssociation",
+      "variant": "live",
+      "source_url": "https://yandex.com/dev/direct/doc/dg-v4/en/live/AdImageAssociation",
+      "request": {"method": "AdImageAssociation"},
+      "param_shape": "unknown",
+      "param_fields": [],
+      "required_fields": [],
+      "notes": ["Supported because WSDL/matrix classify it as no-v5 analogue; JSON param shape has not been manually audited yet."]
+    },
+    {
+      "method": "CheckPayment",
+      "variant": "reference",
+      "source_url": "https://yandex.com/dev/direct/doc/dg-v4/en/reference/CheckPayment",
+      "request": {"method": "CheckPayment"},
+      "param_shape": "object",
+      "param_fields": [
+        {"name": "OperationNum", "required": true},
+        {"name": "CustomTransactionID", "required": true}
+      ],
+      "required_fields": ["OperationNum", "CustomTransactionID"],
+      "notes": ["Finance method; live probing requires a real transaction identifier."]
+    },
+    {
+      "method": "CreateInvoice",
+      "variant": "reference",
+      "source_url": "https://yandex.com/dev/direct/doc/dg-v4/en/reference/CreateInvoice",
+      "request": {"method": "CreateInvoice"},
+      "param_shape": "unknown",
+      "param_fields": [],
+      "required_fields": [],
+      "notes": ["Finance method; schema is intentionally left to the official page until manually audited."]
+    },
+    {
+      "method": "CreateNewForecast",
+      "variant": "reference",
+      "source_url": "https://yandex.com/dev/direct/doc/dg-v4/en/reference/CreateNewForecast",
+      "request": {"method": "CreateNewForecast"},
+      "param_shape": "unknown",
+      "param_fields": [],
+      "required_fields": [],
+      "notes": ["Forecast report request; not normalized by the adapter."]
+    },
+    {
+      "method": "CreateNewWordstatReport",
+      "variant": "reference",
+      "source_url": "https://yandex.com/dev/direct/doc/dg-v4/en/reference/CreateNewWordstatReport",
+      "request": {"method": "CreateNewWordstatReport"},
+      "param_shape": "unknown",
+      "param_fields": [],
+      "required_fields": [],
+      "notes": ["Wordstat report request; not normalized by the adapter."]
+    },
+    {
+      "method": "DeleteForecastReport",
+      "variant": "reference",
+      "source_url": "https://yandex.com/dev/direct/doc/dg-v4/en/reference/DeleteForecastReport",
+      "request": {"method": "DeleteForecastReport"},
+      "param_shape": "unknown",
+      "param_fields": [],
+      "required_fields": [],
+      "notes": ["Delete operation; no adapter-side param normalization."]
+    },
+    {
+      "method": "DeleteOfflineReport",
+      "variant": "live",
+      "source_url": "https://yandex.com/dev/direct/doc/dg-v4/en/live/DeleteOfflineReport",
+      "request": {"method": "DeleteOfflineReport"},
+      "param_shape": "unknown",
+      "param_fields": [],
+      "required_fields": [],
+      "notes": ["Live-only offline report delete operation."]
+    },
+    {
+      "method": "DeleteReport",
+      "variant": "reference",
+      "source_url": "https://yandex.com/dev/direct/doc/dg-v4/en/reference/DeleteReport",
+      "request": {"method": "DeleteReport"},
+      "param_shape": "unknown",
+      "param_fields": [],
+      "required_fields": [],
+      "notes": ["Legacy report delete operation with no v5 analogue."]
+    },
+    {
+      "method": "DeleteWordstatReport",
+      "variant": "reference",
+      "source_url": "https://yandex.com/dev/direct/doc/dg-v4/en/reference/DeleteWordstatReport",
+      "request": {"method": "DeleteWordstatReport"},
+      "param_shape": "unknown",
+      "param_fields": [],
+      "required_fields": [],
+      "notes": ["Delete operation; no adapter-side param normalization."]
+    },
+    {
+      "method": "EnableSharedAccount",
+      "variant": "live",
+      "source_url": "https://yandex.com/dev/direct/doc/dg-v4/en/live/EnableSharedAccount",
+      "request": {"method": "EnableSharedAccount"},
+      "param_shape": "unknown",
+      "param_fields": [],
+      "required_fields": [],
+      "notes": ["Shared-account write operation."]
+    },
+    {
+      "method": "GetAvailableVersions",
+      "variant": "reference",
+      "source_url": "https://yandex.com/dev/direct/doc/dg-v4/en/reference/GetAvailableVersions",
+      "request": {"method": "GetAvailableVersions"},
+      "param_shape": "optional-empty",
+      "param_fields": [],
+      "required_fields": [],
+      "notes": ["API metadata method."]
+    },
+    {
+      "method": "GetBannersTags",
+      "variant": "live",
+      "source_url": "https://yandex.com/dev/direct/doc/dg-v4/en/live/GetBannersTags",
+      "request": {"method": "GetBannersTags"},
+      "param_shape": "object",
+      "param_fields": [{"name": "BannerIDS", "required": true}],
+      "required_fields": ["BannerIDS"],
+      "notes": ["Field name uses capital IDS."]
+    },
+    {
+      "method": "GetCampaignsTags",
+      "variant": "live",
+      "source_url": "https://yandex.com/dev/direct/doc/dg-v4/en/live/GetCampaignsTags",
+      "request": {"method": "GetCampaignsTags"},
+      "param_shape": "object",
+      "param_fields": [{"name": "CampaignIDS", "required": true}],
+      "required_fields": ["CampaignIDS"],
+      "notes": ["Field name uses capital IDS."]
+    },
+    {
+      "method": "GetClientsUnits",
+      "variant": "reference",
+      "source_url": "https://yandex.com/dev/direct/doc/dg-v4/en/reference/GetClientsUnits",
+      "request": {"method": "GetClientsUnits"},
+      "param_shape": "array",
+      "param_fields": [],
+      "required_fields": [],
+      "notes": ["param is a list of client logins."]
+    },
+    {
+      "method": "GetCreditLimits",
+      "variant": "reference",
+      "source_url": "https://yandex.com/dev/direct/doc/dg-v4/en/reference/GetCreditLimits",
+      "request": {"method": "GetCreditLimits"},
+      "param_shape": "unknown",
+      "param_fields": [],
+      "required_fields": [],
+      "notes": ["Finance method; requires a financial token."]
+    },
+    {
+      "method": "GetEventsLog",
+      "variant": "live",
+      "source_url": "https://yandex.com/dev/direct/doc/dg-v4/en/live/GetEventsLog",
+      "request": {"method": "GetEventsLog"},
+      "param_shape": "object",
+      "param_fields": [
+        {"name": "TimestampFrom", "required": true},
+        {"name": "Currency", "required": true},
+        {"name": "Logins", "required": false},
+        {"name": "Filter", "required": false},
+        {"name": "Filter.CampaignIDS", "required": false},
+        {"name": "Filter.BannerIDS", "required": false},
+        {"name": "Filter.Phrases", "required": false},
+        {"name": "Filter.EventTypes", "required": false},
+        {"name": "Limit", "required": false},
+        {"name": "Offset", "required": false}
+      ],
+      "required_fields": ["TimestampFrom", "Currency"],
+      "notes": ["Live JSON docs require TimestampFrom and Currency; Logins, Filter, Limit, and Offset are optional."]
+    },
+    {
+      "method": "GetForecast",
+      "variant": "reference",
+      "source_url": "https://yandex.com/dev/direct/doc/dg-v4/en/reference/GetForecast",
+      "request": {"method": "GetForecast"},
+      "param_shape": "unknown",
+      "param_fields": [],
+      "required_fields": [],
+      "notes": ["Forecast retrieval request."]
+    },
+    {
+      "method": "GetForecastList",
+      "variant": "reference",
+      "source_url": "https://yandex.com/dev/direct/doc/dg-v4/en/reference/GetForecastList",
+      "request": {"method": "GetForecastList"},
+      "param_shape": "optional-empty",
+      "param_fields": [],
+      "required_fields": [],
+      "notes": ["Forecast report list request."]
+    },
+    {
+      "method": "GetKeywordsSuggestion",
+      "variant": "reference",
+      "source_url": "https://yandex.com/dev/direct/doc/dg-v4/en/reference/GetKeywordsSuggestion",
+      "request": {"method": "GetKeywordsSuggestion"},
+      "param_shape": "object",
+      "param_fields": [{"name": "Keywords", "required": true}],
+      "required_fields": ["Keywords"],
+      "notes": ["Phrase suggestions use a Keywords array."]
+    },
+    {
+      "method": "GetRetargetingGoals",
+      "variant": "live",
+      "source_url": "https://yandex.com/dev/direct/doc/dg-v4/en/live/GetRetargetingGoals",
+      "request": {"method": "GetRetargetingGoals"},
+      "param_shape": "object",
+      "param_fields": [{"name": "Logins", "required": true}],
+      "required_fields": ["Logins"],
+      "notes": ["Live JSON docs use Logins, not Login and not CampaignIDS."]
+    },
+    {
+      "method": "GetStatGoals",
+      "variant": "reference",
+      "source_url": "https://yandex.com/dev/direct/doc/dg-v4/en/reference/GetStatGoals",
+      "request": {"method": "GetStatGoals"},
+      "param_shape": "object",
+      "param_fields": [{"name": "CampaignID", "required": true}],
+      "required_fields": ["CampaignID"],
+      "notes": ["Reference v4 docs use singular CampaignID."]
+    },
+    {
+      "method": "GetStatGoals",
+      "variant": "live",
+      "source_url": "https://yandex.com/dev/direct/doc/dg-v4/en/live/GetStatGoals",
+      "request": {"method": "GetStatGoals"},
+      "param_shape": "object",
+      "param_fields": [{"name": "CampaignIDS", "required": true}],
+      "required_fields": ["CampaignIDS"],
+      "notes": ["Live JSON docs use CampaignIDS with capital IDS."]
+    },
+    {
+      "method": "GetVersion",
+      "variant": "reference",
+      "source_url": "https://yandex.com/dev/direct/doc/dg-v4/en/reference/GetVersion",
+      "request": {"method": "GetVersion"},
+      "param_shape": "optional-empty",
+      "param_fields": [],
+      "required_fields": [],
+      "notes": ["API metadata method."]
+    },
+    {
+      "method": "GetWordstatReport",
+      "variant": "reference",
+      "source_url": "https://yandex.com/dev/direct/doc/dg-v4/en/reference/GetWordstatReport",
+      "request": {"method": "GetWordstatReport"},
+      "param_shape": "unknown",
+      "param_fields": [],
+      "required_fields": [],
+      "notes": ["Wordstat report retrieval request."]
+    },
+    {
+      "method": "GetWordstatReportList",
+      "variant": "reference",
+      "source_url": "https://yandex.com/dev/direct/doc/dg-v4/en/reference/GetWordstatReportList",
+      "request": {"method": "GetWordstatReportList"},
+      "param_shape": "optional-empty",
+      "param_fields": [],
+      "required_fields": [],
+      "notes": ["Wordstat report list request."]
+    },
+    {
+      "method": "PayCampaigns",
+      "variant": "reference",
+      "source_url": "https://yandex.com/dev/direct/doc/dg-v4/en/reference/PayCampaigns",
+      "request": {"method": "PayCampaigns"},
+      "param_shape": "unknown",
+      "param_fields": [],
+      "required_fields": [],
+      "notes": ["Finance method; requires a financial token."]
+    },
+    {
+      "method": "PayCampaignsByCard",
+      "variant": "reference",
+      "source_url": "https://yandex.com/dev/direct/doc/dg-v4/en/reference/PayCampaignsByCard",
+      "request": {"method": "PayCampaignsByCard"},
+      "param_shape": "unknown",
+      "param_fields": [],
+      "required_fields": [],
+      "notes": ["Finance method; requires a financial token."]
+    },
+    {
+      "method": "PingAPI",
+      "variant": "reference",
+      "source_url": "https://yandex.com/dev/direct/doc/dg-v4/en/reference/PingAPI",
+      "request": {"method": "PingAPI"},
+      "param_shape": "optional-empty",
+      "param_fields": [],
+      "required_fields": [],
+      "notes": ["API metadata method."]
+    },
+    {
+      "method": "PingAPI_X",
+      "variant": "reference",
+      "source_url": "https://yandex.com/dev/direct/doc/dg-v4/en/reference/PingAPI_X",
+      "request": {"method": "PingAPI_X"},
+      "param_shape": "optional-empty",
+      "param_fields": [],
+      "required_fields": [],
+      "notes": ["API metadata method."]
+    },
+    {
+      "method": "TransferMoney",
+      "variant": "reference",
+      "source_url": "https://yandex.com/dev/direct/doc/dg-v4/en/reference/TransferMoney",
+      "request": {"method": "TransferMoney"},
+      "param_shape": "unknown",
+      "param_fields": [],
+      "required_fields": [],
+      "notes": ["Finance method; requires a financial token."]
+    },
+    {
+      "method": "UpdateBannersTags",
+      "variant": "live",
+      "source_url": "https://yandex.com/dev/direct/doc/dg-v4/en/live/UpdateBannersTags",
+      "request": {"method": "UpdateBannersTags"},
+      "param_shape": "unknown",
+      "param_fields": [],
+      "required_fields": [],
+      "notes": ["Live-only tag update operation."]
+    },
+    {
+      "method": "UpdateCampaignsTags",
+      "variant": "live",
+      "source_url": "https://yandex.com/dev/direct/doc/dg-v4/en/live/UpdateCampaignsTags",
+      "request": {"method": "UpdateCampaignsTags"},
+      "param_shape": "unknown",
+      "param_fields": [],
+      "required_fields": [],
+      "notes": ["Live-only tag update operation."]
+    }
+  ]
+}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 markers =
-    live: hits the real Yandex Direct API; requires YANDEX_DIRECT_TOKEN env var
+    live: hits the real Yandex Direct API; requires YANDEX_DIRECT_TOKEN and YANDEX_DIRECT_LOGIN env vars

--- a/scripts/audit_v4_json_docs.py
+++ b/scripts/audit_v4_json_docs.py
@@ -1,0 +1,215 @@
+"""Audit the local v4/v4 Live JSON documentation snapshot.
+
+The v4 WSDL tells us which operations exist. It does not describe the JSON
+RPC request body accurately enough for v4 Live, where every operation goes to
+one endpoint and the method-specific payload lives under ``param``. This helper
+therefore treats ``docs/v4_json_contracts.json`` as the local source of truth
+for method/param shape and cross-checks it against the WSDL-derived matrix.
+
+Default mode is offline and CI-safe. ``--refresh-from-online`` only fetches the
+official source pages and records a refresh timestamp; schema changes still
+need a human to review and edit the JSON snapshot.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.request import Request, urlopen
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_SNAPSHOT = ROOT / "docs" / "v4_json_contracts.json"
+DEFAULT_MATRIX = ROOT / "docs" / "v4_methods_matrix.md"
+AUDIT_WSDL = ROOT / "scripts" / "audit_wsdl.py"
+
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+VALID_VARIANTS = {"reference", "live"}
+VALID_PARAM_SHAPES = {"array", "object", "optional-empty", "scalar", "unknown"}
+
+
+def load_snapshot(path: Path = DEFAULT_SNAPSHOT) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def write_snapshot(snapshot: dict[str, Any], path: Path = DEFAULT_SNAPSHOT) -> None:
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(snapshot, fh, ensure_ascii=False, indent=2)
+        fh.write("\n")
+
+
+def _load_audit_wsdl():
+    spec = importlib.util.spec_from_file_location("audit_wsdl", AUDIT_WSDL)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load {AUDIT_WSDL}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_supported_methods() -> dict[str, dict[str, Any]]:
+    from tapi_yandex_direct.v4 import SUPPORTED_V4_METHODS
+
+    return SUPPORTED_V4_METHODS
+
+
+def parse_matrix_statuses(path: Path = DEFAULT_MATRIX) -> dict[str, str]:
+    statuses: dict[str, str] = {}
+    row_re = re.compile(r"^\|\s*\d+\s*\|\s*`([^`]+)`\s*\|[^|]*\|\s*([^|]+?)\s*\|")
+    in_full_table = False
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line == "## Full method table":
+            in_full_table = True
+            continue
+        if in_full_table and line.startswith("## "):
+            break
+        if not in_full_table:
+            continue
+        match = row_re.match(line)
+        if match:
+            statuses[match.group(1)] = match.group(2).strip()
+    return statuses
+
+
+def contracts_by_method(snapshot: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for contract in snapshot.get("contracts", []):
+        grouped.setdefault(contract.get("method"), []).append(contract)
+    return grouped
+
+
+def validate_snapshot(
+    snapshot: dict[str, Any] | None = None,
+    *,
+    matrix_path: Path = DEFAULT_MATRIX,
+) -> list[str]:
+    snapshot = snapshot or load_snapshot()
+    errors: list[str] = []
+    supported = load_supported_methods()
+    audit_wsdl = _load_audit_wsdl()
+    matrix_statuses = parse_matrix_statuses(matrix_path)
+    grouped = contracts_by_method(snapshot)
+
+    missing = sorted(set(supported) - set(grouped))
+    stale = sorted(set(grouped) - set(supported))
+    if missing:
+        errors.append(f"Snapshot misses supported methods: {missing}")
+    if stale:
+        errors.append(f"Snapshot has stale methods: {stale}")
+
+    for method in sorted(supported):
+        if method not in audit_wsdl.V4_TO_V5_MAP:
+            errors.append(f"{method} missing from V4_TO_V5_MAP")
+        elif audit_wsdl.V4_TO_V5_MAP[method] is not None:
+            errors.append(
+                f"{method} is supported but maps to v5 "
+                f"{audit_wsdl.V4_TO_V5_MAP[method]!r}"
+            )
+
+        if matrix_statuses.get(method) != "actual_no_v5_analogue":
+            errors.append(
+                f"{method} matrix status is "
+                f"{matrix_statuses.get(method)!r}, expected actual_no_v5_analogue"
+            )
+
+    seen_keys: set[tuple[str, str]] = set()
+    for index, contract in enumerate(snapshot.get("contracts", [])):
+        label = f"contracts[{index}]"
+        method = contract.get("method")
+        variant = contract.get("variant")
+        key = (method, variant)
+        if key in seen_keys:
+            errors.append(f"{label} duplicates {method}/{variant}")
+        seen_keys.add(key)
+
+        if not method:
+            errors.append(f"{label} missing method")
+        if variant not in VALID_VARIANTS:
+            errors.append(f"{label} has invalid variant {variant!r}")
+        if not str(contract.get("source_url", "")).startswith(
+            "https://yandex.com/dev/direct/doc/dg-v4/en/"
+        ):
+            errors.append(f"{label} has invalid source_url")
+        request = contract.get("request")
+        if not isinstance(request, dict) or request.get("method") != method:
+            errors.append(f"{label} request.method must equal method")
+        if contract.get("param_shape") not in VALID_PARAM_SHAPES:
+            errors.append(f"{label} has invalid param_shape")
+
+        fields = contract.get("param_fields")
+        if not isinstance(fields, list):
+            errors.append(f"{label} param_fields must be a list")
+            fields = []
+        field_names = [field.get("name") for field in fields if isinstance(field, dict)]
+        required = contract.get("required_fields")
+        if not isinstance(required, list):
+            errors.append(f"{label} required_fields must be a list")
+            required = []
+        missing_required = sorted(set(required) - set(field_names))
+        if missing_required:
+            errors.append(f"{label} required fields absent from param_fields: {missing_required}")
+
+    return errors
+
+
+def _fetch_text(url: str, timeout: int) -> str:
+    request = Request(url, headers={"User-Agent": "tapi-yandex-direct-audit/1.0"})
+    with urlopen(request, timeout=timeout) as response:
+        return response.read().decode("utf-8", errors="replace")
+
+
+def refresh_from_online(snapshot: dict[str, Any], *, timeout: int) -> dict[str, Any]:
+    refreshed = json.loads(json.dumps(snapshot))
+    for contract in refreshed.get("contracts", []):
+        html = _fetch_text(contract["source_url"], timeout)
+        contract["online_check"] = {
+            "fetched_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+            "method_found": contract["method"] in html,
+            "fields_found": [
+                field["name"]
+                for field in contract.get("param_fields", [])
+                if isinstance(field, dict) and field.get("name") in html
+            ],
+        }
+    refreshed.setdefault("metadata", {})["refreshed_at"] = (
+        datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    )
+    return refreshed
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--snapshot", type=Path, default=DEFAULT_SNAPSHOT)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--refresh-from-online", action="store_true")
+    parser.add_argument("--timeout", type=int, default=20)
+    args = parser.parse_args(argv)
+
+    snapshot = load_snapshot(args.snapshot)
+    if args.refresh_from_online:
+        snapshot = refresh_from_online(snapshot, timeout=args.timeout)
+        write_snapshot(snapshot, args.output or args.snapshot)
+
+    errors = validate_snapshot(snapshot)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+
+    print(
+        f"v4 JSON docs snapshot OK: "
+        f"{len(contracts_by_method(snapshot))} supported methods covered"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit_v4_json_docs.py
+++ b/scripts/audit_v4_json_docs.py
@@ -178,7 +178,11 @@ def refresh_from_online(snapshot: dict[str, Any], *, timeout: int) -> dict[str, 
             "fields_found": [
                 field["name"]
                 for field in contract.get("param_fields", [])
-                if isinstance(field, dict) and field.get("name") in html
+                if (
+                    isinstance(field, dict)
+                    and isinstance(field.get("name"), str)
+                    and field["name"] in html
+                )
             ],
         }
     refreshed.setdefault("metadata", {})["refreshed_at"] = (

--- a/scripts/audit_v4_json_docs.py
+++ b/scripts/audit_v4_json_docs.py
@@ -168,16 +168,20 @@ def _fetch_text(url: str, timeout: int) -> str:
 def refresh_from_online(snapshot: dict[str, Any], *, timeout: int) -> dict[str, Any]:
     refreshed = json.loads(json.dumps(snapshot))
     for contract in refreshed.get("contracts", []):
-        source_url = contract["source_url"]
+        source_url = contract.get("source_url")
         if not str(source_url).startswith(OFFICIAL_V4_DOCS_PREFIX):
             raise ValueError(f"Refusing to fetch unexpected URL: {source_url!r}")
         html = _fetch_text(source_url, timeout)
+        method = contract.get("method")
+        param_fields = contract.get("param_fields", [])
+        if not isinstance(param_fields, list):
+            param_fields = []
         contract["online_check"] = {
             "fetched_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
-            "method_found": contract["method"] in html,
+            "method_found": isinstance(method, str) and method in html,
             "fields_found": [
                 field["name"]
-                for field in contract.get("param_fields", [])
+                for field in param_fields
                 if (
                     isinstance(field, dict)
                     and isinstance(field.get("name"), str)

--- a/scripts/audit_v4_json_docs.py
+++ b/scripts/audit_v4_json_docs.py
@@ -27,6 +27,7 @@ ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_SNAPSHOT = ROOT / "docs" / "v4_json_contracts.json"
 DEFAULT_MATRIX = ROOT / "docs" / "v4_methods_matrix.md"
 AUDIT_WSDL = ROOT / "scripts" / "audit_wsdl.py"
+OFFICIAL_V4_DOCS_PREFIX = "https://yandex.com/dev/direct/doc/dg-v4/en/"
 
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
@@ -99,7 +100,7 @@ def validate_snapshot(
     grouped = contracts_by_method(snapshot)
 
     missing = sorted(set(supported) - set(grouped))
-    stale = sorted(set(grouped) - set(supported))
+    stale = sorted(key for key in set(grouped) - set(supported) if key is not None)
     if missing:
         errors.append(f"Snapshot misses supported methods: {missing}")
     if stale:
@@ -134,9 +135,7 @@ def validate_snapshot(
             errors.append(f"{label} missing method")
         if variant not in VALID_VARIANTS:
             errors.append(f"{label} has invalid variant {variant!r}")
-        if not str(contract.get("source_url", "")).startswith(
-            "https://yandex.com/dev/direct/doc/dg-v4/en/"
-        ):
+        if not str(contract.get("source_url", "")).startswith(OFFICIAL_V4_DOCS_PREFIX):
             errors.append(f"{label} has invalid source_url")
         request = contract.get("request")
         if not isinstance(request, dict) or request.get("method") != method:
@@ -169,7 +168,10 @@ def _fetch_text(url: str, timeout: int) -> str:
 def refresh_from_online(snapshot: dict[str, Any], *, timeout: int) -> dict[str, Any]:
     refreshed = json.loads(json.dumps(snapshot))
     for contract in refreshed.get("contracts", []):
-        html = _fetch_text(contract["source_url"], timeout)
+        source_url = contract["source_url"]
+        if not str(source_url).startswith(OFFICIAL_V4_DOCS_PREFIX):
+            raise ValueError(f"Refusing to fetch unexpected URL: {source_url!r}")
+        html = _fetch_text(source_url, timeout)
         contract["online_check"] = {
             "fetched_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
             "method_found": contract["method"] in html,

--- a/scripts/audit_wsdl.py
+++ b/scripts/audit_wsdl.py
@@ -13,6 +13,8 @@ Usage:
     python scripts/audit_wsdl.py --issue
 """
 
+from __future__ import annotations
+
 import argparse
 import os
 import re

--- a/tests/test_v4_json_docs.py
+++ b/tests/test_v4_json_docs.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import importlib.util
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 from tapi_yandex_direct.v4 import SUPPORTED_V4_METHODS
 from tapi_yandex_direct.v4.adapter import V4LiveClientAdapter
@@ -15,6 +16,8 @@ AUDIT_SCRIPT_PATH = ROOT / "scripts" / "audit_v4_json_docs.py"
 
 
 spec = importlib.util.spec_from_file_location("audit_v4_json_docs", AUDIT_SCRIPT_PATH)
+if spec is None or spec.loader is None:
+    raise ImportError(f"Could not load audit_v4_json_docs from {AUDIT_SCRIPT_PATH}")
 audit_v4_json_docs = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(audit_v4_json_docs)
 
@@ -43,6 +46,47 @@ def _field_names(contract: dict) -> set[str]:
 
 def test_v4_json_docs_snapshot_is_internally_valid():
     assert audit_v4_json_docs.validate_snapshot(_snapshot()) == []
+
+
+def test_v4_json_docs_snapshot_reports_missing_method_without_crashing():
+    snapshot = {
+        "contracts": [
+            {
+                "variant": "live",
+                "source_url": "https://yandex.com/dev/direct/doc/dg-v4/en/live/Broken",
+                "request": {"method": "Broken"},
+                "param_shape": "object",
+                "param_fields": [],
+                "required_fields": [],
+            }
+        ]
+    }
+
+    errors = audit_v4_json_docs.validate_snapshot(snapshot)
+
+    assert "contracts[0] missing method" in errors
+
+
+def test_v4_json_docs_refresh_refuses_non_official_urls_before_fetch():
+    snapshot = {
+        "contracts": [
+            {
+                "method": "GetEventsLog",
+                "source_url": "https://example.com/not-yandex",
+                "param_fields": [],
+            }
+        ]
+    }
+
+    with patch.object(audit_v4_json_docs, "_fetch_text") as fetch_text:
+        try:
+            audit_v4_json_docs.refresh_from_online(snapshot, timeout=1)
+        except ValueError as err:
+            assert "Refusing to fetch unexpected URL" in str(err)
+        else:
+            raise AssertionError("refresh_from_online accepted a non-official URL")
+
+    fetch_text.assert_not_called()
 
 
 def test_v4_json_docs_snapshot_covers_supported_methods():

--- a/tests/test_v4_json_docs.py
+++ b/tests/test_v4_json_docs.py
@@ -105,6 +105,8 @@ def test_v4_json_docs_snapshot_covers_supported_methods():
 def test_supported_v4_methods_are_no_v5_analogue_in_wsdl_audit():
     audit_wsdl_path = ROOT / "scripts" / "audit_wsdl.py"
     spec = importlib.util.spec_from_file_location("audit_wsdl", audit_wsdl_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not load audit_wsdl from {audit_wsdl_path}")
     audit_wsdl = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(audit_wsdl)
 

--- a/tests/test_v4_json_docs.py
+++ b/tests/test_v4_json_docs.py
@@ -116,6 +116,27 @@ def test_v4_json_docs_refresh_ignores_fields_without_names():
     ]
 
 
+def test_v4_json_docs_refresh_handles_missing_method_and_bad_fields():
+    snapshot = {
+        "contracts": [
+            {
+                "source_url": "https://yandex.com/dev/direct/doc/dg-v4/en/live/GetEventsLog",
+                "param_fields": None,
+            }
+        ]
+    }
+
+    with patch.object(
+        audit_v4_json_docs,
+        "_fetch_text",
+        return_value="GetEventsLog TimestampFrom",
+    ):
+        refreshed = audit_v4_json_docs.refresh_from_online(snapshot, timeout=1)
+
+    assert refreshed["contracts"][0]["online_check"]["method_found"] is False
+    assert refreshed["contracts"][0]["online_check"]["fields_found"] == []
+
+
 def test_v4_json_docs_snapshot_covers_supported_methods():
     grouped = audit_v4_json_docs.contracts_by_method(_snapshot())
 

--- a/tests/test_v4_json_docs.py
+++ b/tests/test_v4_json_docs.py
@@ -89,6 +89,33 @@ def test_v4_json_docs_refresh_refuses_non_official_urls_before_fetch():
     fetch_text.assert_not_called()
 
 
+def test_v4_json_docs_refresh_ignores_fields_without_names():
+    snapshot = {
+        "contracts": [
+            {
+                "method": "GetEventsLog",
+                "source_url": "https://yandex.com/dev/direct/doc/dg-v4/en/live/GetEventsLog",
+                "param_fields": [
+                    {},
+                    {"name": None},
+                    {"name": "TimestampFrom"},
+                ],
+            }
+        ]
+    }
+
+    with patch.object(
+        audit_v4_json_docs,
+        "_fetch_text",
+        return_value="TimestampFrom Currency",
+    ):
+        refreshed = audit_v4_json_docs.refresh_from_online(snapshot, timeout=1)
+
+    assert refreshed["contracts"][0]["online_check"]["fields_found"] == [
+        "TimestampFrom"
+    ]
+
+
 def test_v4_json_docs_snapshot_covers_supported_methods():
     grouped = audit_v4_json_docs.contracts_by_method(_snapshot())
 

--- a/tests/test_v4_json_docs.py
+++ b/tests/test_v4_json_docs.py
@@ -1,0 +1,138 @@
+"""Docs-driven v4/v4 Live JSON contract tests."""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+from tapi_yandex_direct.v4 import SUPPORTED_V4_METHODS
+from tapi_yandex_direct.v4.adapter import V4LiveClientAdapter
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SNAPSHOT_PATH = ROOT / "docs" / "v4_json_contracts.json"
+AUDIT_SCRIPT_PATH = ROOT / "scripts" / "audit_v4_json_docs.py"
+
+
+spec = importlib.util.spec_from_file_location("audit_v4_json_docs", AUDIT_SCRIPT_PATH)
+audit_v4_json_docs = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(audit_v4_json_docs)
+
+
+def _snapshot() -> dict:
+    return audit_v4_json_docs.load_snapshot(SNAPSHOT_PATH)
+
+
+def _contracts() -> list[dict]:
+    return _snapshot()["contracts"]
+
+
+def _contract(method: str, variant: str = "live") -> dict:
+    matches = [
+        contract
+        for contract in _contracts()
+        if contract["method"] == method and contract["variant"] == variant
+    ]
+    assert len(matches) == 1
+    return matches[0]
+
+
+def _field_names(contract: dict) -> set[str]:
+    return {field["name"] for field in contract["param_fields"]}
+
+
+def test_v4_json_docs_snapshot_is_internally_valid():
+    assert audit_v4_json_docs.validate_snapshot(_snapshot()) == []
+
+
+def test_v4_json_docs_snapshot_covers_supported_methods():
+    grouped = audit_v4_json_docs.contracts_by_method(_snapshot())
+
+    assert set(grouped) == set(SUPPORTED_V4_METHODS)
+    for method, contracts in grouped.items():
+        assert contracts
+        for contract in contracts:
+            assert contract["request"]["method"] == method
+            assert contract["source_url"].startswith(
+                "https://yandex.com/dev/direct/doc/dg-v4/en/"
+            )
+
+
+def test_supported_v4_methods_are_no_v5_analogue_in_wsdl_audit():
+    audit_wsdl_path = ROOT / "scripts" / "audit_wsdl.py"
+    spec = importlib.util.spec_from_file_location("audit_wsdl", audit_wsdl_path)
+    audit_wsdl = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(audit_wsdl)
+
+    for method in SUPPORTED_V4_METHODS:
+        assert method in audit_wsdl.V4_TO_V5_MAP
+        assert audit_wsdl.V4_TO_V5_MAP[method] is None
+
+
+def test_supported_v4_methods_are_actual_candidates_in_matrix():
+    statuses = audit_v4_json_docs.parse_matrix_statuses(
+        ROOT / "docs" / "v4_methods_matrix.md"
+    )
+
+    for method in SUPPORTED_V4_METHODS:
+        assert statuses[method] == "actual_no_v5_analogue"
+
+
+def test_get_stat_goals_keeps_reference_and_live_param_spellings():
+    reference = _contract("GetStatGoals", "reference")
+    live = _contract("GetStatGoals", "live")
+
+    assert reference["required_fields"] == ["CampaignID"]
+    assert _field_names(reference) == {"CampaignID"}
+    assert live["required_fields"] == ["CampaignIDS"]
+    assert _field_names(live) == {"CampaignIDS"}
+
+
+def test_get_retargeting_goals_live_uses_logins_param():
+    live = _contract("GetRetargetingGoals", "live")
+
+    assert live["param_shape"] == "object"
+    assert live["required_fields"] == ["Logins"]
+    assert _field_names(live) == {"Logins"}
+
+
+def test_get_events_log_live_documents_required_and_optional_fields():
+    live = _contract("GetEventsLog", "live")
+
+    assert live["required_fields"] == ["TimestampFrom", "Currency"]
+    assert {
+        "TimestampFrom",
+        "Currency",
+        "Logins",
+        "Filter",
+        "Filter.CampaignIDS",
+        "Filter.BannerIDS",
+        "Filter.Phrases",
+        "Filter.EventTypes",
+        "Limit",
+        "Offset",
+    } <= _field_names(live)
+
+
+def test_adapter_adds_transport_fields_without_mutating_param_shape():
+    adapter = V4LiveClientAdapter()
+    api_params = {
+        "access_token": "token",
+        "login": "client-login",
+        "language": "en",
+        "is_sandbox": False,
+    }
+    param = {"Logins": ["client-login"]}
+
+    request = adapter.get_request_kwargs(
+        api_params,
+        data={"method": "GetRetargetingGoals", "param": param},
+    )
+    body = json.loads(request["data"])
+
+    assert body["method"] == "GetRetargetingGoals"
+    assert body["param"] == {"Logins": ["client-login"]}
+    assert param == {"Logins": ["client-login"]}
+    assert body["token"] == "token"
+    assert body["locale"] == "en"
+    assert request["headers"]["Client-Login"] == "client-login"

--- a/tests/test_v4_live_integration.py
+++ b/tests/test_v4_live_integration.py
@@ -6,6 +6,7 @@ Run locally with::
 
     export YANDEX_DIRECT_TOKEN=...   (real OAuth token)
     export YANDEX_DIRECT_LOGIN=...   (account login)
+    export YANDEX_DIRECT_SANDBOX=1   (optional; use sandbox endpoints)
     pytest tests/test_v4_live_integration.py -v -m live
 
 The probes intentionally cover only **read-only** v4 Live operations and one
@@ -34,6 +35,8 @@ def v4_kwargs() -> dict:
     return {
         "access_token": os.environ["YANDEX_DIRECT_TOKEN"],
         "login": os.environ["YANDEX_DIRECT_LOGIN"],
+        "is_sandbox": os.environ.get("YANDEX_DIRECT_SANDBOX", "").lower()
+        in {"1", "true", "yes"},
     }
 
 
@@ -50,29 +53,36 @@ def real_ids(v4_kwargs) -> dict:
     v4 Live tag/goal probes need real entities; v5 is the cleanest source.
     """
     from tapi_yandex_direct import YandexDirect
+    from tapi_yandex_direct import exceptions as exc
 
     v5 = YandexDirect(**v4_kwargs)
-    camps = v5.campaigns().post(data={
-        "method": "get",
-        "params": {
-            "SelectionCriteria": {},
-            "FieldNames": ["Id"],
-            "Page": {"Limit": 1},
-        },
-    })
+    try:
+        camps = v5.campaigns().post(data={
+            "method": "get",
+            "params": {
+                "SelectionCriteria": {},
+                "FieldNames": ["Id"],
+                "Page": {"Limit": 1},
+            },
+        })
+    except exc.YandexDirectClientError as err:
+        pytest.skip(f"could not resolve real campaign ids via v5: {err}")
     camp_list = camps().extract()
     if not camp_list:
         pytest.skip("account has no campaigns to probe against")
     cid: int = camp_list[0]["Id"]
 
-    ads = v5.ads().post(data={
-        "method": "get",
-        "params": {
-            "SelectionCriteria": {"CampaignIds": [cid]},
-            "FieldNames": ["Id"],
-            "Page": {"Limit": 1},
-        },
-    })
+    try:
+        ads = v5.ads().post(data={
+            "method": "get",
+            "params": {
+                "SelectionCriteria": {"CampaignIds": [cid]},
+                "FieldNames": ["Id"],
+                "Page": {"Limit": 1},
+            },
+        })
+    except exc.YandexDirectClientError as err:
+        pytest.skip(f"could not resolve real banner ids via v5: {err}")
     ads_list = ads().extract()
     bid = ads_list[0]["Id"] if ads_list else None
     return {"campaign_id": cid, "banner_id": bid}
@@ -89,17 +99,6 @@ def test_get_clients_units(v4_client, v4_kwargs):
     assert isinstance(extracted, list) and extracted
     assert extracted[0]["Login"] == v4_kwargs["login"]
     assert isinstance(extracted[0]["UnitsRest"], int)
-
-
-@pytest.mark.live
-def test_get_retargeting_goals(v4_client, v4_kwargs):
-    res = v4_client.v4live().post(data={
-        "method": "GetRetargetingGoals", "param": {"Login": v4_kwargs["login"]},
-    })
-    goals = res().extract()
-    assert isinstance(goals, list)
-    if goals:
-        assert "GoalID" in goals[0]
 
 
 @pytest.mark.live
@@ -131,6 +130,19 @@ def test_get_stat_goals(v4_client, real_ids):
     if extracted:
         assert "GoalID" in extracted[0]
         assert extracted[0]["CampaignID"] == real_ids["campaign_id"]
+
+
+@pytest.mark.live
+def test_get_retargeting_goals(v4_client, v4_kwargs):
+    """Per live JSON docs: GetRetargetingGoals uses Logins."""
+    res = v4_client.v4live().post(data={
+        "method": "GetRetargetingGoals",
+        "param": {"Logins": [v4_kwargs["login"]]},
+    })
+    goals = res().extract()
+    assert isinstance(goals, list)
+    if goals:
+        assert "GoalID" in goals[0]
 
 
 @pytest.mark.live
@@ -168,12 +180,15 @@ def test_get_banners_tags(v4_client, real_ids):
 # ------- methods with non-trivial schemas -------
 
 @pytest.mark.live
-def test_get_events_log(v4_client):
+def test_get_events_log(v4_client, v4_kwargs):
     """Per docs: TimestampFrom must be ISO 8601 AND Currency is required."""
     ts = (datetime.now(timezone.utc) - timedelta(days=7)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    param = {"TimestampFrom": ts, "Currency": "RUB", "Limit": 3}
+    if v4_kwargs["is_sandbox"]:
+        param["Logins"] = [v4_kwargs["login"]]
     res = v4_client.v4live().post(data={
         "method": "GetEventsLog",
-        "param": {"TimestampFrom": ts, "Currency": "RUB", "Limit": 3},
+        "param": param,
     })
     events = res().extract()
     assert isinstance(events, list)


### PR DESCRIPTION
## Summary
- add a local v4/v4 Live JSON docs snapshot and offline audit helper
- replace the direct-cli-style contract test with docs-driven JSON contract tests
- correct GetRetargetingGoals Live docs/tests to use param.Logins and clarify adapter param handling
- expand CI to run the v4 resource, live-adapter, docs-audit, and WSDL audit tests

## Validation
- python3 scripts/audit_v4_json_docs.py
- python3 -m pytest tests/tests.py tests/test_resource_mapping.py tests/test_v4_live.py tests/test_v4_json_docs.py tests/test_audit_wsdl.py -q
- live read-only subset from ~/Projects/direct-cli/.env: 12 passed, 2 deselected
- secret scan of changed/untracked files: no non-placeholder secret-like patterns found