### PR TITLE
fix(v5): bound retry_request limit/units retries to prevent infinite loop (#23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,15 +80,15 @@ client = YandexDirect(
     is_sandbox=False,
     # Repeat request when units run out
     retry_if_not_enough_units=False,
-    # Number of retries when units run out.
+    # Maximum total request attempts when units run out (includes the initial attempt).
     retries_if_not_enough_units=5,
     # The language in which the data for directories and errors will be returned.
     language="ru",
     # Repeat the request if the limits on the number of reports or requests are exceeded.
     retry_if_exceeded_limit=True,
-    # Number of retries when report/request limits are exceeded.
+    # Maximum total request attempts when report/request limits are exceeded (includes the initial attempt).
     retries_if_exceeded_limit=5,
-    # Number of retries when server errors occur.
+    # Maximum total request attempts when server errors occur (includes the initial attempt).
     retries_if_server_error=5
 )
 ```
@@ -345,15 +345,15 @@ client = YandexDirect(
     is_sandbox=False,
     # Repeat request when units run out
     retry_if_not_enough_units=False,
-    # Number of retries when units run out.
+    # Maximum total request attempts when units run out (includes the initial attempt).
     retries_if_not_enough_units=5,
     # The language in which the data for directories and errors will be returned.
     language="ru",
     # Repeat the request if the limits on the number of reports or requests are exceeded.
     retry_if_exceeded_limit=True,
-    # Number of retries when report/request limits are exceeded.
+    # Maximum total request attempts when report/request limits are exceeded (includes the initial attempt).
     retries_if_exceeded_limit=5,
-    # Number of retries when server errors occur.
+    # Maximum total request attempts when server errors occur (includes the initial attempt).
     retries_if_server_error=5,
 
     # Report resource parameters:

--- a/README.md
+++ b/README.md
@@ -80,10 +80,14 @@ client = YandexDirect(
     is_sandbox=False,
     # Repeat request when units run out
     retry_if_not_enough_units=False,
+    # Number of retries when units run out.
+    retries_if_not_enough_units=5,
     # The language in which the data for directories and errors will be returned.
     language="ru",
     # Repeat the request if the limits on the number of reports or requests are exceeded.
     retry_if_exceeded_limit=True,
+    # Number of retries when report/request limits are exceeded.
+    retries_if_exceeded_limit=5,
     # Number of retries when server errors occur.
     retries_if_server_error=5
 )
@@ -341,10 +345,14 @@ client = YandexDirect(
     is_sandbox=False,
     # Repeat request when units run out
     retry_if_not_enough_units=False,
+    # Number of retries when units run out.
+    retries_if_not_enough_units=5,
     # The language in which the data for directories and errors will be returned.
     language="ru",
     # Repeat the request if the limits on the number of reports or requests are exceeded.
     retry_if_exceeded_limit=True,
+    # Number of retries when report/request limits are exceeded.
+    retries_if_exceeded_limit=5,
     # Number of retries when server errors occur.
     retries_if_server_error=5,
 

--- a/tapi_yandex_direct/tapi_yandex_direct.py
+++ b/tapi_yandex_direct/tapi_yandex_direct.py
@@ -273,6 +273,7 @@ class YandexDirectClientAdapter(JSONAdapterMixin, TapiAdapter):
                 logger.warning("API requests exceeded, re-request after 10 seconds")
                 time.sleep(10)
                 return True
+            logger.error("API requests exceeded, retries exhausted")
             return False
 
         elif error_code == 56 and api_params.get("retry_if_exceeded_limit", True):
@@ -282,6 +283,7 @@ class YandexDirectClientAdapter(JSONAdapterMixin, TapiAdapter):
                 )
                 time.sleep(10)
                 return True
+            logger.error("Method request limit exceeded, retries exhausted")
             return False
 
         elif error_code == 9000 and api_params.get("retry_if_exceeded_limit", True):
@@ -291,6 +293,7 @@ class YandexDirectClientAdapter(JSONAdapterMixin, TapiAdapter):
                 )
                 time.sleep(10)
                 return True
+            logger.error("Max number of reports limit exceeded, retries exhausted")
             return False
 
         elif error_code in (52, 1000, 1001, 1002) or status_code == 500:

--- a/tapi_yandex_direct/tapi_yandex_direct.py
+++ b/tapi_yandex_direct/tapi_yandex_direct.py
@@ -250,29 +250,48 @@ class YandexDirectClientAdapter(JSONAdapterMixin, TapiAdapter):
                 return True
 
         if error_code == 152:
+            # "Not enough units" is an API-points quota error, distinct from the
+            # rate-limit codes below: points replenish on a sliding 60-minute
+            # window, so the retry waits 5 minutes and uses its own budget
+            # (retries_if_not_enough_units) rather than the rate-limit budget.
+            # Without a cap the loop would be infinite (sleep, retry, forever).
             if api_params.get("retry_if_not_enough_units", False):
-                logger.warning("Not enough units, re-request after 5 minutes")
-                time.sleep(60 * 5)
-                return True
+                if repeat_number < api_params.get("retries_if_not_enough_units", 5):
+                    logger.warning("Not enough units, re-request after 5 minutes")
+                    time.sleep(60 * 5)
+                    return True
+                logger.error("Not enough units to request, retries exhausted")
+                return False
             else:
                 logger.error("Not enough units to request")
 
         elif error_code == 506 and api_params.get("retry_if_exceeded_limit", True):
-            logger.warning("API requests exceeded, re-request after 10 seconds")
-            time.sleep(10)
-            return True
+            # Bound rate-limit retries with their own attempt budget. Without
+            # this cap the loop is infinite (sleep 10s, retry, forever) whenever
+            # the API keeps returning the limit code — which hangs the caller.
+            if repeat_number < api_params.get("retries_if_exceeded_limit", 5):
+                logger.warning("API requests exceeded, re-request after 10 seconds")
+                time.sleep(10)
+                return True
+            return False
 
         elif error_code == 56 and api_params.get("retry_if_exceeded_limit", True):
-            logger.warning("Method request limit exceeded. Re-request after 10 seconds")
-            time.sleep(10)
-            return True
+            if repeat_number < api_params.get("retries_if_exceeded_limit", 5):
+                logger.warning(
+                    "Method request limit exceeded. Re-request after 10 seconds"
+                )
+                time.sleep(10)
+                return True
+            return False
 
         elif error_code == 9000 and api_params.get("retry_if_exceeded_limit", True):
-            logger.warning(
-                "Created by max number of reports. Re-request after 10 seconds"
-            )
-            time.sleep(10)
-            return True
+            if repeat_number < api_params.get("retries_if_exceeded_limit", 5):
+                logger.warning(
+                    "Created by max number of reports. Re-request after 10 seconds"
+                )
+                time.sleep(10)
+                return True
+            return False
 
         elif error_code in (52, 1000, 1001, 1002) or status_code == 500:
             if repeat_number < api_params.get("retries_if_server_error", 5):

--- a/tapi_yandex_direct/tapi_yandex_direct.pyi
+++ b/tapi_yandex_direct/tapi_yandex_direct.pyi
@@ -101,7 +101,9 @@ class YandexDirect:
         login: str = None,
         is_sandbox: bool = False,
         retry_if_not_enough_units: bool = False,
+        retries_if_not_enough_units: int = 5,
         retry_if_exceeded_limit: bool = True,
+        retries_if_exceeded_limit: int = 5,
         retries_if_server_error: int = 5,
         language: str = None,
         processing_mode: str = "offline",
@@ -119,7 +121,9 @@ class YandexDirect:
         :param login: If you are making inquiries from an agent account, you must be sure to specify the account login.
         :param is_sandbox: Enable sandbox.
         :param retry_if_not_enough_units: Repeat request when units run out
+        :param retries_if_not_enough_units: Number of retries when units run out.
         :param retry_if_exceeded_limit: Repeat the request if the limits on the number of reports or requests are exceeded.
+        :param retries_if_exceeded_limit: Number of retries when report/request limits are exceeded.
         :param retries_if_server_error: Number of retries when server errors occur.
         :param language: The language in which the data for directories and errors will be returned.
 

--- a/tapi_yandex_direct/tapi_yandex_direct.pyi
+++ b/tapi_yandex_direct/tapi_yandex_direct.pyi
@@ -121,10 +121,10 @@ class YandexDirect:
         :param login: If you are making inquiries from an agent account, you must be sure to specify the account login.
         :param is_sandbox: Enable sandbox.
         :param retry_if_not_enough_units: Repeat request when units run out
-        :param retries_if_not_enough_units: Number of retries when units run out.
+        :param retries_if_not_enough_units: Maximum total request attempts when units run out (includes the initial attempt; default 5 = 1 initial + 4 retries).
         :param retry_if_exceeded_limit: Repeat the request if the limits on the number of reports or requests are exceeded.
-        :param retries_if_exceeded_limit: Number of retries when report/request limits are exceeded.
-        :param retries_if_server_error: Number of retries when server errors occur.
+        :param retries_if_exceeded_limit: Maximum total request attempts when report/request limits are exceeded (includes the initial attempt; default 5 = 1 initial + 4 retries).
+        :param retries_if_server_error: Maximum total request attempts when server errors occur (includes the initial attempt; default 5 = 1 initial + 4 retries).
         :param language: The language in which the data for directories and errors will be returned.
 
         :param processing_mode: (report resource) Report generation mode: online, offline or auto.

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,8 +1,11 @@
 import logging
 
+import pytest
 import responses
 
+import tapi_yandex_direct.tapi_yandex_direct as adapter_mod
 from tapi_yandex_direct import YandexDirect
+from tapi_yandex_direct import exceptions as exc
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -329,3 +332,121 @@ def test_agencyclients_add_passport_organization_member():
     )
     assert result.data == {"result": {"AddResults": [{"Login": "member-login"}]}}
     assert result().extract() == [{"Login": "member-login"}]
+
+
+def _v5_error(code):
+    # v5 errors nest under "error". The adapter reads error["code"]; the
+    # exception constructor reads error_code/request_id/error_string/
+    # error_detail — both sets of keys must be present.
+    return {
+        "error": {
+            "code": code,
+            "error_code": code,
+            "request_id": "test-request-id",
+            "error_string": "Limit exceeded",
+            "error_detail": "test detail",
+        }
+    }
+
+
+@responses.activate
+def test_v5_persistent_limit_506_stops_and_raises(monkeypatch):
+    # Regression guard for issue #23: a persistent limit code must NOT loop
+    # forever. With retries_if_exceeded_limit=2 the adapter makes exactly
+    # 2 HTTP calls then raises, instead of hanging.
+    monkeypatch.setattr(adapter_mod.time, "sleep", lambda _s: None)
+
+    for _ in range(5):
+        responses.add(
+            responses.POST,
+            "https://api.direct.yandex.com/json/v5/clients",
+            json=_v5_error(506),
+            status=200,
+        )
+
+    local_client = YandexDirect(
+        access_token="",
+        retry_if_exceeded_limit=True,
+        retries_if_exceeded_limit=2,
+        retries_if_server_error=5,
+    )
+    with pytest.raises(exc.YandexDirectRequestsLimitError):
+        local_client.clients().post(
+            data={"method": "get", "params": {"FieldNames": ["ClientId"]}}
+        )
+    assert len(responses.calls) == 2
+
+
+@responses.activate
+def test_v5_limit_506_retries_then_succeeds(monkeypatch):
+    monkeypatch.setattr(adapter_mod.time, "sleep", lambda _s: None)
+
+    responses.add(
+        responses.POST,
+        "https://api.direct.yandex.com/json/v5/clients",
+        json=_v5_error(506),
+        status=200,
+    )
+    responses.add(
+        responses.POST,
+        "https://api.direct.yandex.com/json/v5/clients",
+        json={"result": {"Clients": []}},
+        status=200,
+    )
+
+    local_client = YandexDirect(
+        access_token="",
+        retry_if_exceeded_limit=True,
+        retries_if_exceeded_limit=5,
+        retries_if_server_error=5,
+    )
+    result = local_client.clients().post(
+        data={"method": "get", "params": {"FieldNames": ["ClientId"]}}
+    )
+    assert result().extract() == []
+    assert len(responses.calls) == 2
+
+
+@responses.activate
+def test_v5_limit_506_raises_when_retry_disabled():
+    # Module-level `client` has retry_if_exceeded_limit=False, so a limit code
+    # is raised immediately with no retry.
+    responses.add(
+        responses.POST,
+        "https://api.direct.yandex.com/json/v5/clients",
+        json=_v5_error(506),
+        status=200,
+    )
+    with pytest.raises(exc.YandexDirectRequestsLimitError):
+        client.clients().post(
+            data={"method": "get", "params": {"FieldNames": ["ClientId"]}}
+        )
+    assert len(responses.calls) == 1
+
+
+@responses.activate
+def test_v5_persistent_units_152_stops_and_raises(monkeypatch):
+    # Regression guard for issue #23: code 152 ("not enough units") is opt-in
+    # (retry_if_not_enough_units) and now bounded by its own
+    # retries_if_not_enough_units budget — it must stop, not loop forever.
+    monkeypatch.setattr(adapter_mod.time, "sleep", lambda _s: None)
+
+    for _ in range(5):
+        responses.add(
+            responses.POST,
+            "https://api.direct.yandex.com/json/v5/clients",
+            json=_v5_error(152),
+            status=200,
+        )
+
+    local_client = YandexDirect(
+        access_token="",
+        retry_if_not_enough_units=True,
+        retries_if_not_enough_units=2,
+        retries_if_server_error=5,
+    )
+    with pytest.raises(exc.YandexDirectNotEnoughUnitsError):
+        local_client.clients().post(
+            data={"method": "get", "params": {"FieldNames": ["ClientId"]}}
+        )
+    assert len(responses.calls) == 2

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -349,18 +349,21 @@ def _v5_error(code):
     }
 
 
+@pytest.mark.parametrize("code", [506, 56, 9000])
 @responses.activate
-def test_v5_persistent_limit_506_stops_and_raises(monkeypatch):
+def test_v5_persistent_limit_stops_and_raises(monkeypatch, code):
     # Regression guard for issue #23: a persistent limit code must NOT loop
     # forever. With retries_if_exceeded_limit=2 the adapter makes exactly
-    # 2 HTTP calls then raises, instead of hanging.
+    # 2 HTTP calls then raises, instead of hanging. Codes 506/56/9000 each go
+    # through their own elif branch but share the retries_if_exceeded_limit
+    # budget, so all three are exercised.
     monkeypatch.setattr(adapter_mod.time, "sleep", lambda _s: None)
 
     for _ in range(5):
         responses.add(
             responses.POST,
             "https://api.direct.yandex.com/json/v5/clients",
-            json=_v5_error(506),
+            json=_v5_error(code),
             status=200,
         )
 


### PR DESCRIPTION
## Зачем

При ревью PR #22 робот-ревьюер нашёл, что v5-адаптер (`YandexDirectClientAdapter.retry_request`) страдает тем же классом бага, что был исправлен для v4: ветки лимит-кодов **506, 56, 9000** (и opt-in **152**) делали `time.sleep(...); return True` **без проверки `repeat_number`**. Если API упорно возвращает лимит-ошибку, вызывающий зависает навсегда — тот же риск, что direct-cli #454. Баг предсуществующий (PR #22 эти строки не трогал), поэтому вынесен в issue #23.

## Что сделано

| Код | Категория | Бюджет ретраев |
|---|---|---|
| 506 / 56 / 9000 | rate/concurrency limit (очищается за секунды) | новый `retries_if_exceeded_limit` (default 5) |
| 152 | API-баллы / квота (пополняется по скользящему окну раз в 60 мин) | свой `retries_if_not_enough_units` (default 5), задержка 5 мин сохранена |

**Почему 152 отдельно.** По коду и по [документации Яндекса](https://yandex.ru/dev/direct/doc/ru/concepts/units) код 152 «Недостаточно баллов» — это квота API-баллов (своё исключение `YandexDirectNotEnoughUnitsError`, свой opt-in флаг `retry_if_not_enough_units`, задержка 5 минут), а не rate-limit. Баллы пополняются по скользящему 60-минутному окну; Яндекс рекомендует ≤5 ретраев. Переиспользовать rate-limit бюджет для 152 было бы концептуально неверно — поэтому отдельный счётчик.

- Оба новых int-параметра добавлены в стаб `.pyi` (с docstring) и в README. Дефолты (5) сохраняют поведение.
- v5-регрессионные тесты: персистентные 506 и 152 останавливаются после бюджета и бросают исключение (нет бесконечного цикла); одна ошибка 506 → успех = 1 ретрай; лимит-код при отключённых ретраях бросает сразу.

## Проверка

- `ruff check` по изменённым файлам кода — чисто (единственная ошибка F811 в `tests/tests.py` — предсуществующий дубль `test_iter_items`, вне scope).
- `pytest tests/` → 56 passed, 14 skipped.

Closes #23