### PR TITLE
fix(docs): point removed-doc services at live WSDL

### DIFF
--- a/tapi_yandex_direct/resource_mapping.py
+++ b/tapi_yandex_direct/resource_mapping.py
@@ -76,14 +76,20 @@ RESOURCE_MAPPING_V5 = {
         "docs": "https://yandex.ru/dev/direct/doc/ru/dictionaries/dictionaries",
         "methods": ["get"],
     },
+    # Yandex removed the human-readable doc pages for DynamicTextAdTargets,
+    # DynamicFeedAdTargets, SmartAdTargets and VCards in September 2025 (the
+    # /ru/ and /en/ pages now 404, and the services are gone from the docs
+    # navigation). The services themselves remain live, so `docs` points at the
+    # WSDL endpoint — the only authoritative source still served for them. See
+    # issue #463.
     "dynamicads": {
         "resource": "json/v5/dynamictextadtargets",
-        "docs": "https://yandex.ru/dev/direct/doc/ru/dynamictextadtargets",
+        "docs": "https://api.direct.yandex.com/v5/dynamictextadtargets?wsdl",
         "methods": ["get", "add", "delete", "suspend", "resume", "setBids"],
     },
     "dynamicfeedadtargets": {
         "resource": "json/v5/dynamicfeedadtargets",
-        "docs": "https://yandex.ru/dev/direct/doc/ru/dynamicfeedadtargets",
+        "docs": "https://api.direct.yandex.com/v5/dynamicfeedadtargets?wsdl",
         "methods": ["get", "add", "delete", "suspend", "resume", "setBids"],
     },
     "keywordbids": {
@@ -118,7 +124,8 @@ RESOURCE_MAPPING_V5 = {
     },
     "vcards": {
         "resource": "json/v5/vcards",
-        "docs": "https://yandex.ru/dev/direct/doc/ru/vcards",
+        # Doc page removed Sep 2025 (see comment above); WSDL still live.
+        "docs": "https://api.direct.yandex.com/v5/vcards?wsdl",
         "methods": ["get", "add", "delete"],
     },
     "turbopages": {
@@ -154,7 +161,8 @@ RESOURCE_MAPPING_V5 = {
     },
     "smartadtargets": {
         "resource": "json/v5/smartadtargets",
-        "docs": "https://yandex.ru/dev/direct/doc/ru/smartadtargets",
+        # Doc page removed Sep 2025 (see comment above); WSDL still live.
+        "docs": "https://api.direct.yandex.com/v5/smartadtargets?wsdl",
         "methods": ["get", "add", "update", "delete", "suspend", "resume", "setBids"],
     },
     "strategies": {


### PR DESCRIPTION
## Problem

Yandex removed the human-readable doc pages for **DynamicTextAdTargets**, **DynamicFeedAdTargets**, **SmartAdTargets** and **VCards** in September 2025. The `…/dev/direct/doc/ru/<service>` pages now return **HTTP 404** and the services are gone from the docs navigation. The services themselves stay live.

`RESOURCE_MAPPING_V5` still pointed the `docs` field of these 4 services at the dead HTML pages.

## Fix

Repoint the 4 `docs` URLs at their live WSDL endpoints (`https://api.direct.yandex.com/v5/<service>?wsdl`) — the only authoritative source still served for them — with a comment explaining the Sep-2025 removal.

The `docs` field is metadata-only (never used at runtime; requests build from `resource`), so this has **no functional impact**.

## Why at the source

The downstream `axisrow/direct-cli` project vendors this package via `rm -rf` + `cp -R`. It fixed this same drift in its vendored copy (direct-cli #463 / #464), but a later vendor sync silently overwrote that fix with this file's dead URLs. Re-applying the fix here, at the source, stops vendor syncs from re-introducing the 404 URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)